### PR TITLE
Allow endpoints to be versioned via a controller

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/HelloWorldController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/HelloWorldController.java
@@ -1,9 +1,11 @@
 package org.opm.busybeaver;
 
+import org.opm.busybeaver.controller.ApiPrefixController;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@ApiPrefixController
 public class HelloWorldController {
 
     private static final String template = "Welcome, to Busy Beaver Project Management!";

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ApiPrefixController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ApiPrefixController.java
@@ -1,0 +1,17 @@
+package org.opm.busybeaver.controller;
+
+import org.springframework.core.annotation.AliasFor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Component
+@RequestMapping("/v1")
+public @interface  ApiPrefixController {
+    @AliasFor(annotation = Component.class)
+    String value() default "";
+}

--- a/backend/busybeaver/src/main/resources/application.properties
+++ b/backend/busybeaver/src/main/resources/application.properties
@@ -1,1 +1,1 @@
-
+server.servlet.context-path=/api


### PR DESCRIPTION
Adds the `ApiPrefixController` to allow endpoints to be versioned appropriately if a new version if the API is released.

To test, head to the `~/backend/busybeaver` folder, and run using `./gradlew bootRun`

Then, visit `localhost:8080/api/v1/greeting` to see the versioning in action.

Response will still contain the Hello World JSON - 

`{"content":"Welcome, to Busy Beaver Project Management!"}`

Closes #22 