### PR TITLE
Add timestamp to Tasks/Projects, add Task Index, Unique User per Team/Project

### DIFF
--- a/database/RecreateOPMDatabase.sql
+++ b/database/RecreateOPMDatabase.sql
@@ -46,6 +46,7 @@ CREATE TABLE Projects (
     project_name VARCHAR(50) NOT NULL,
     current_sprint_id INTEGER,
     team_id INTEGER REFERENCES Teams(team_id) NOT NULL,
+    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
 
     -- Enforce uniqueness of project per team
     CONSTRAINT unique_project_per_team UNIQUE (project_name, team_id)
@@ -97,7 +98,9 @@ CREATE TABLE Tasks (
     title VARCHAR(100) NOT NULL,
     description VARCHAR(500), -- Enforcing 500 character maximum
     custom_fields JSONB,
-    task_created TIMESTAMP
+    task_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    task_index SMALLINT DEFAULT -1
 );
 
 DROP TABLE IF EXISTS Comments CASCADE;

--- a/database/RecreateOPMDatabase.sql
+++ b/database/RecreateOPMDatabase.sql
@@ -37,7 +37,10 @@ CREATE TABLE TeamUsers (
     user_team_id SERIAL PRIMARY KEY,
     user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL,
     team_id INTEGER REFERENCES Teams(team_id) NOT NULL,
-    user_team_role VARCHAR(20) DEFAULT 'User' CHECK (user_team_role IN ('User', 'Creator', 'Mod'))
+    user_team_role VARCHAR(20) DEFAULT 'User' CHECK (user_team_role IN ('User', 'Creator', 'Mod')),
+
+    -- Enforce user can't be in table twice
+    CONSTRAINT unique_user_per_team UNIQUE (user_id, team_id)
 );
 
 DROP TABLE IF EXISTS Projects CASCADE;
@@ -58,6 +61,9 @@ CREATE TABLE ProjectUsers (
     user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL,
     project_id INTEGER REFERENCES Projects(project_id) NOT NULL,
     user_project_role VARCHAR(20) Default 'Member' CHECK (user_project_role IN ('Member', 'Dev', 'Project Manager', 'Manager', 'External', 'Manager'))
+
+    -- Enforce user can't be in team twice
+    CONSTRAINT unique_user_per_project UNIQUE (user_id, project_id)
 );
 
 DROP TABLE IF EXISTS Sprints CASCADE;


### PR DESCRIPTION
Adds a `last_updated` field to both Tasks and Projects, which will be updated whenever something is internally updated within them.

Adds a `task_index` field to the Tasks table with a default of -1, to provide a future method of reordering if necessary.

UPDATE: Enforce unique user and team/project constraints, so user can't be in team or project more than once.