### PR TITLE
Add ON DELETE options for referenced foreign keys

### DIFF
--- a/database/RecreateOPMDatabase.sql
+++ b/database/RecreateOPMDatabase.sql
@@ -26,7 +26,7 @@ DROP TABLE IF EXISTS Teams CASCADE;
 CREATE TABLE Teams (
     team_id SERIAL PRIMARY KEY,
     team_name VARCHAR(50) NOT NULL,
-    team_creator INTEGER REFERENCES BeaverUsers(user_id) NOT NULL,
+    team_creator INTEGER NOT NULL REFERENCES BeaverUsers(user_id),
 
     -- Enforce uniqueness per team creator of team name
     CONSTRAINT unique_team_per_creator UNIQUE (team_name, team_creator)
@@ -35,8 +35,8 @@ CREATE TABLE Teams (
 DROP TABLE IF EXISTS TeamUsers CASCADE;
 CREATE TABLE TeamUsers (
     user_team_id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL ON DELETE CASCADE,
-    team_id INTEGER REFERENCES Teams(team_id) NOT NULL ON DELETE CASCADE,
+    user_id INTEGER NOT NULL REFERENCES BeaverUsers(user_id) ON DELETE CASCADE,
+    team_id INTEGER NOT NULL REFERENCES Teams(team_id) ON DELETE CASCADE,
     user_team_role VARCHAR(20) DEFAULT 'User' CHECK (user_team_role IN ('User', 'Creator', 'Mod')),
 
     -- Enforce user can't be in table twice
@@ -48,7 +48,7 @@ CREATE TABLE Projects (
     project_id SERIAL PRIMARY KEY,
     project_name VARCHAR(50) NOT NULL,
     current_sprint_id INTEGER,
-    team_id INTEGER REFERENCES Teams(team_id) NOT NULL ON DELETE CASCADE,
+    team_id INTEGER NOT NULL REFERENCES Teams(team_id) ON DELETE CASCADE,
     last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
 
     -- Enforce uniqueness of project per team
@@ -58,9 +58,9 @@ CREATE TABLE Projects (
 DROP TABLE IF EXISTS ProjectUsers CASCADE;
 CREATE TABLE ProjectUsers (
     user_project_id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL ON DELETE CASCADE,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
-    user_project_role VARCHAR(20) Default 'Member' CHECK (user_project_role IN ('Member', 'Dev', 'Project Manager', 'Manager', 'External', 'Manager'))
+    user_id INTEGER NOT NULL REFERENCES BeaverUsers(user_id) ON DELETE CASCADE,
+    project_id INTEGER NOT NULL REFERENCES Projects(project_id) ON DELETE CASCADE,
+    user_project_role VARCHAR(20) Default 'Member' CHECK (user_project_role IN ('Member', 'Dev', 'Project Manager', 'Manager', 'External', 'Manager')),
 
     -- Enforce user can't be in team twice
     CONSTRAINT unique_user_per_project UNIQUE (user_id, project_id)
@@ -70,7 +70,7 @@ DROP TABLE IF EXISTS Sprints CASCADE;
 CREATE TABLE Sprints (
     sprint_id SERIAL PRIMARY KEY,
     sprint_name VARCHAR(50) NOT NULL,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
+    project_id INTEGER NOT NULL REFERENCES Projects(project_id) ON DELETE CASCADE,
     begin_date DATE NOT NULL,
     end_date DATE NOT NULL,
 
@@ -84,7 +84,7 @@ ALTER TABLE Projects ADD CONSTRAINT fk_project_sprint FOREIGN KEY (current_sprin
 DROP TABLE IF EXISTS Columns CASCADE;
 CREATE TABLE Columns (
     column_id SERIAL PRIMARY KEY,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
+    project_id INTEGER NOT NULL REFERENCES Projects(project_id) ON DELETE CASCADE,
     column_title VARCHAR(50) NOT NULL,
     column_index SMALLINT NOT NULL, -- The order of the column in the Project
 

--- a/database/RecreateOPMDatabase.sql
+++ b/database/RecreateOPMDatabase.sql
@@ -35,8 +35,8 @@ CREATE TABLE Teams (
 DROP TABLE IF EXISTS TeamUsers CASCADE;
 CREATE TABLE TeamUsers (
     user_team_id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL,
-    team_id INTEGER REFERENCES Teams(team_id) NOT NULL,
+    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL ON DELETE CASCADE,
+    team_id INTEGER REFERENCES Teams(team_id) NOT NULL ON DELETE CASCADE,
     user_team_role VARCHAR(20) DEFAULT 'User' CHECK (user_team_role IN ('User', 'Creator', 'Mod')),
 
     -- Enforce user can't be in table twice
@@ -48,7 +48,7 @@ CREATE TABLE Projects (
     project_id SERIAL PRIMARY KEY,
     project_name VARCHAR(50) NOT NULL,
     current_sprint_id INTEGER,
-    team_id INTEGER REFERENCES Teams(team_id) NOT NULL,
+    team_id INTEGER REFERENCES Teams(team_id) NOT NULL ON DELETE CASCADE,
     last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
 
     -- Enforce uniqueness of project per team
@@ -58,8 +58,8 @@ CREATE TABLE Projects (
 DROP TABLE IF EXISTS ProjectUsers CASCADE;
 CREATE TABLE ProjectUsers (
     user_project_id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL,
+    user_id INTEGER REFERENCES BeaverUsers(user_id) NOT NULL ON DELETE CASCADE,
+    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
     user_project_role VARCHAR(20) Default 'Member' CHECK (user_project_role IN ('Member', 'Dev', 'Project Manager', 'Manager', 'External', 'Manager'))
 
     -- Enforce user can't be in team twice
@@ -70,7 +70,7 @@ DROP TABLE IF EXISTS Sprints CASCADE;
 CREATE TABLE Sprints (
     sprint_id SERIAL PRIMARY KEY,
     sprint_name VARCHAR(50) NOT NULL,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL,
+    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
     begin_date DATE NOT NULL,
     end_date DATE NOT NULL,
 
@@ -84,7 +84,7 @@ ALTER TABLE Projects ADD CONSTRAINT fk_project_sprint FOREIGN KEY (current_sprin
 DROP TABLE IF EXISTS Columns CASCADE;
 CREATE TABLE Columns (
     column_id SERIAL PRIMARY KEY,
-    project_id INTEGER REFERENCES Projects(project_id) NOT NULL,
+    project_id INTEGER REFERENCES Projects(project_id) NOT NULL ON DELETE CASCADE,
     column_title VARCHAR(50) NOT NULL,
     column_index SMALLINT NOT NULL, -- The order of the column in the Project
 
@@ -95,8 +95,8 @@ CREATE TABLE Columns (
 DROP TABLE IF EXISTS Tasks CASCADE;
 CREATE TABLE Tasks (
     task_id SERIAL PRIMARY KEY,
-    sprint_id INTEGER REFERENCES Sprints(sprint_id), -- Tasks can start unassociated with a sprint by default
-    assigned_to INTEGER REFERENCES ProjectUsers(user_project_id), -- Tasks can start unassigned by default
+    sprint_id INTEGER REFERENCES Sprints(sprint_id) ON DELETE SET NULL, -- Tasks can start unassociated with a sprint by default
+    assigned_to INTEGER REFERENCES ProjectUsers(user_project_id) ON DELETE SET NULL, -- Tasks can start unassigned by default
     column_id INTEGER REFERENCES Columns(column_id) NOT NULL, -- Tasks cannot start unassociated with a column by default
     project_id INTEGER REFERENCES Projects(project_id) NOT NULL,
     priority VARCHAR(20) Default 'None' CHECK (priority IN ('None', 'Low', 'Medium', 'High')),
@@ -112,8 +112,8 @@ CREATE TABLE Tasks (
 DROP TABLE IF EXISTS Comments CASCADE;
 CREATE TABLE Comments (
     comment_id SERIAL PRIMARY KEY,
-    user_id INTEGER REFERENCES ProjectUsers(user_project_id),
-    task_id INTEGER REFERENCES Tasks(task_id),
+    user_id INTEGER REFERENCES ProjectUsers(user_project_id) ON DELETE SET NULL,
+    task_id INTEGER REFERENCES Tasks(task_id) ON DELETE CASCADE,
     comment_created TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     comment_body TEXT
 );


### PR DESCRIPTION
Allow deletes to cascade through depending on if the parent indicated by the foreign key is also deleted.

Details:

Deleting a USER will now delete all associated TeamUsers rows and ProjectUsers rows.
Deleting a TEAM will now DELETE all associated Projects (will need additional business logic here to verify the projects are available to delete, do not contain tasks, etc)
Deleting a PROJECT will now delete all associated SPRINT rows
Deleting a PROJECT will now delete all associated COLUMN rows
Deleting a SPRINT will set to NULL the Foreign Key for Sprints in a  Task
Deleting a USER will set to NULL the assigned user of a TASK
Deleting a USER will set to NULL the author of a comment
Deleting a TASK will delete all associated COMMENT rows