### PR TITLE
DELETE project, GET specific task details including comments

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectController.java
@@ -7,9 +7,11 @@ import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerToken
 import org.opm.busybeaver.dto.Projects.NewProjectDto;
 import org.opm.busybeaver.dto.Projects.ProjectDetailsDto;
 import org.opm.busybeaver.dto.Projects.ProjectsSummariesDto;
+import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.BusyBeavPaths;
+import org.opm.busybeaver.enums.SuccessMessageConstants;
 import org.opm.busybeaver.service.ProjectService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -39,6 +41,20 @@ public final class ProjectController implements GetUserFromBearerTokenInterface 
         response.setStatus(HttpStatus.CREATED.value());
 
         return projectDto;
+    }
+
+    @DeleteMapping(PROJECTS_PATH + "/{projectID}")
+    public SmallJsonResponse deleteProject(
+            HttpServletRequest request,
+            @PathVariable int projectID,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        projectService.deleteProject(userDto, projectID);
+
+        return new SmallJsonResponse(
+                HttpStatus.OK.value(),
+                SuccessMessageConstants.PROJECT_DELETED.getValue()
+        );
     }
 
     @GetMapping(PROJECTS_PATH)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
@@ -7,6 +7,7 @@ import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerToken
 import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Tasks.NewTaskDto;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
+import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.BusyBeavPaths;
@@ -27,6 +28,16 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
 
     @Autowired
     public TasksController (TaskService taskService) { this.taskService = taskService; }
+
+    @GetMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")
+    public TaskDetailsDto getTaskDetails(
+            HttpServletRequest request,
+            @PathVariable int projectID,
+            @PathVariable int taskID,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        return taskService.getTaskDetails(userDto, projectID, taskID, request.getContextPath());
+    }
 
     @PostMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH)
     public TaskCreatedDto addTask(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Columns/ColumnInTaskDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Columns/ColumnInTaskDto.java
@@ -1,0 +1,40 @@
+package org.opm.busybeaver.dto.Columns;
+
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+public final class ColumnInTaskDto {
+    private final String columnTitle;
+    private final int columnID;
+    private final int columnIndex;
+    private String columnLocation;
+
+    public ColumnInTaskDto(String columnTitle, int columnID, int columnIndex) {
+        this.columnTitle = columnTitle;
+        this.columnID = columnID;
+        this.columnIndex = columnIndex;
+    }
+
+    public void setColumnLocation(String contextPath, int projectID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.columnLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.COLUMNS.getValue() + "/" + getColumnID();
+    }
+
+    public String getColumnTitle() {
+        return columnTitle;
+    }
+
+    public int getColumnID() {
+        return columnID;
+    }
+
+    public int getColumnIndex() {
+        return columnIndex;
+    }
+
+    public String getColumnLocation() {
+        return columnLocation;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Comments/CommentInTaskDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Comments/CommentInTaskDto.java
@@ -1,0 +1,58 @@
+package org.opm.busybeaver.dto.Comments;
+
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import java.beans.ConstructorProperties;
+import java.time.LocalDateTime;
+
+public class CommentInTaskDto {
+    private final int commentID;
+    private final String commentBody;
+    private final String commenterUsername;
+    private final int commenterID;
+
+    private final LocalDateTime commentedAt;
+    private String commentLocation;
+
+    @ConstructorProperties({"comment_id", "comment_body", "username", "user_id", "comment_created"})
+    public CommentInTaskDto(int commentID, String commentBody, String commenter, int commenterID, LocalDateTime commentedAt) {
+        this.commentID = commentID;
+        this.commentBody = commentBody;
+        this.commenterUsername = commenter;
+        this.commenterID  = commenterID;
+        this.commentedAt = commentedAt;
+    }
+
+    public void setCommentLocation(String contextPath, int projectID, int taskID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.commentLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.TASKS.getValue() + "/" + taskID +
+                BusyBeavPaths.COMMENTS.getValue() + "/" + getCommentID();
+    }
+
+    public int getCommentID() {
+        return commentID;
+    }
+
+    public String getCommentBody() {
+        return commentBody;
+    }
+
+    public String getCommenterUsername() {
+        return commenterUsername;
+    }
+
+    public int getCommenterID() {
+        return commenterID;
+    }
+
+    public LocalDateTime getCommentedAt() {
+        return commentedAt;
+    }
+
+    public String getCommentLocation() {
+        return commentLocation;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/SprintInTaskDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/SprintInTaskDto.java
@@ -1,0 +1,48 @@
+package org.opm.busybeaver.dto.Sprints;
+
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import java.time.LocalDate;
+
+public final class SprintInTaskDto {
+    private final int sprintID;
+    private final String sprintName;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private String sprintLocation;
+
+    public SprintInTaskDto(int sprintID, String sprintName, LocalDate startDate, LocalDate endDate) {
+        this.sprintID = sprintID;
+        this.sprintName = sprintName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void setSprintLocation(String contextPath, int projectID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.sprintLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.SPRINTS.getValue() + "/" + getSprintID();
+    }
+
+    public LocalDate getStartDate () {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getSprintName() {
+        return sprintName;
+    }
+
+    public int getSprintID() {
+        return sprintID;
+    }
+
+    public String getSprintLocation() {
+        return sprintLocation;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskDetailsDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskDetailsDto.java
@@ -1,0 +1,113 @@
+package org.opm.busybeaver.dto.Tasks;
+
+import org.opm.busybeaver.dto.Columns.ColumnInTaskDto;
+import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
+import org.opm.busybeaver.dto.Sprints.SprintInTaskDto;
+import org.opm.busybeaver.dto.Users.UserSummaryDto;
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import javax.annotation.Nullable;
+import java.beans.ConstructorProperties;
+import java.time.LocalDate;
+import java.util.List;
+
+public final class TaskDetailsDto {
+    private final int taskID;
+    private final String title;
+    @Nullable
+    private final String description;
+    private final String priority;
+    private final ColumnInTaskDto columnInTaskDto;
+    @Nullable
+    private UserSummaryDto assignedTo;
+    @Nullable
+    private SprintInTaskDto sprintInTaskDto;
+    private List<CommentInTaskDto> comments;
+
+    private String taskLocation;
+
+    @ConstructorProperties({"task_id", "title", "description", "priority",
+                            "column_id", "column_title", "column_index",
+                            "user_id", "username",
+                            "sprint_id", "begin_date", "end_date", "sprint_name"})
+    public TaskDetailsDto(int taskID, String title, @Nullable String description, String priority,
+                          int columnID, String columnTitle, int columnIndex,
+                          Integer userID, String username,
+                          Integer sprintID, LocalDate startDate, LocalDate endDate, String sprintName) {
+        this.taskID = taskID;
+        this.title = title;
+        this.description = description;
+        this.priority = priority;
+
+        this.columnInTaskDto = new ColumnInTaskDto(columnTitle, columnID, columnIndex);
+
+        if (userID != null && username != null) {
+            this.assignedTo = new UserSummaryDto(username, userID);
+        }
+
+        if (sprintID != null) {
+            this.sprintInTaskDto = new SprintInTaskDto(sprintID, sprintName, startDate, endDate);
+        }
+    }
+
+    public void setComments(List<CommentInTaskDto> comments) {
+        this.comments = comments;
+    }
+
+    public void setTaskLocation(String contextPath, int projectID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.taskLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.TASKS.getValue() + "/" + getTaskID();
+
+        columnInTaskDto.setColumnLocation(contextPath, projectID);
+
+        if (sprintInTaskDto != null) {
+            sprintInTaskDto.setSprintLocation(contextPath, projectID);
+        }
+
+        if (!comments.isEmpty()) {
+            comments.forEach(comment -> comment.setCommentLocation(contextPath, projectID, getTaskID()));
+        }
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public int getTaskID() {
+        return taskID;
+    }
+
+    @Nullable
+    public String getDescription() {
+        return description;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public ColumnInTaskDto getColumnInTaskDto() {
+        return columnInTaskDto;
+    }
+
+    @Nullable
+    public UserSummaryDto getAssignedTo() {
+        return assignedTo;
+    }
+
+    @Nullable
+    public SprintInTaskDto getSprintInTaskDto() {
+        return sprintInTaskDto;
+    }
+
+    public List<CommentInTaskDto> getComments() {
+        return comments;
+    }
+
+    public String getTaskLocation() {
+        return taskLocation;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/BusyBeavPaths.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/BusyBeavPaths.java
@@ -11,6 +11,7 @@ public enum BusyBeavPaths {
     TASKS(Constants.TASKS),
     SPRINTS(Constants.SPRINTS),
     COLUMNS(Constants.COLUMNS),
+    COMMENTS(Constants.COMMENTS),
     AUTH(Constants.AUTH);
 
     private final String value;
@@ -30,5 +31,6 @@ public enum BusyBeavPaths {
         public static final String SPRINTS = "/sprints";
         public static final String COLUMNS = "/columns";
         public static final String MEMBERS = "/members";
+        public static final String COMMENTS = "/comments";
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
@@ -29,7 +29,8 @@ public enum ErrorMessageConstants {
     MISSING_INVALID_HEADER_TOKEN("Missing or invalid authentication header and token."),
     USER_ALREADY_IN_PROJECT("User already in this project"),
     USER_NOT_IN_PROJECT("User not in this project"),
-    PROJECT_CANNOT_HAVE_ZERO_USERS("The last member of a project cannot remove themselves");
+    PROJECT_CANNOT_HAVE_ZERO_USERS("The last member of a project cannot remove themselves"),
+    PROJECT_STILL_HAS_TASKS("Projects must have no tasks left before they can be deleted");
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
@@ -9,7 +9,8 @@ public enum SuccessMessageConstants {
     TASK_DELETED("Task deleted"),
     COLUMN_DELETED("Column removed from project"),
     USER_WAS_ADDED_TO_PROJECT(" was added to the project"), // Place username in front
-    USER_WAS_REMOVED_FROM_PROJECT(" was removed from the project"); // Place username in front
+    USER_WAS_REMOVED_FROM_PROJECT(" was removed from the project"),
+    PROJECT_DELETED("Project deleted"); // Place username in front
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptionHandler.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptionHandler.java
@@ -31,4 +31,15 @@ public class ProjectsExceptionHandler {
                 HttpStatus.FORBIDDEN
         );
     }
+
+    @ExceptionHandler(ProjectsExceptions.ProjectMustHaveZeroTasksBeforeDeletion.class)
+    public ResponseEntity<?> projectMustHaveZeroTasksBeforeDeletion() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.PROJECT_STILL_HAS_TASKS.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptions.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptions.java
@@ -12,4 +12,10 @@ public final class ProjectsExceptions {
             super(errorMessage);
         }
     }
+
+    public static class ProjectMustHaveZeroTasksBeforeDeletion extends RuntimeException {
+        public ProjectMustHaveZeroTasksBeforeDeletion(String errorMessage) {
+            super(errorMessage);
+        }
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/CommentRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/CommentRepository.java
@@ -1,0 +1,48 @@
+package org.opm.busybeaver.repository;
+
+import org.jooq.DSLContext;
+import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static org.opm.busybeaver.jooq.Tables.*;
+
+@Repository
+@Component
+public class CommentRepository {
+
+    private final DSLContext create;
+
+    @Autowired
+    public CommentRepository(DSLContext dslContext) {
+        this.create = dslContext;
+    }
+
+    public List<CommentInTaskDto> getCommentsOnTask(int taskID) {
+        // SELECT Comments.comment_id, Comments.comment_body, BeaverUsers.username,
+        //          Comments.user_id, Comments.commented_created
+        // FROM Comments
+        // JOIN ProjectUsers
+        // ON Comments.user_id = ProjectUsers.user_project_id
+        // JOIN BeaverUsers
+        // ON ProjectUsers.user_id = BeaverUsers.user_id
+        // WHERE Comments.task_id = taskID;
+        return create.select(
+                        COMMENTS.COMMENT_ID,
+                        COMMENTS.COMMENT_BODY,
+                        BEAVERUSERS.USERNAME,
+                        COMMENTS.USER_ID,
+                        COMMENTS.COMMENT_CREATED)
+                .from(COMMENTS)
+                .join(PROJECTUSERS)
+                .on(COMMENTS.USER_ID.eq(PROJECTUSERS.USER_PROJECT_ID))
+                .join(BEAVERUSERS)
+                .on(PROJECTUSERS.USER_ID.eq(BEAVERUSERS.USER_ID))
+                .where(COMMENTS.TASK_ID.eq(taskID))
+                .orderBy(COMMENTS.COMMENT_CREATED.asc())
+                .fetchInto(CommentInTaskDto.class);
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectRepository.java
@@ -94,6 +94,10 @@ public class ProjectRepository {
         }
     }
 
+    public void deleteProject(int projectID) {
+        create.deleteFrom(PROJECTS).where(PROJECTS.PROJECT_ID.eq(projectID)).execute();
+    }
+
     @NotNull
     private static ArrayList<ProjectusersRecord> createProjectusersRecords(List<TeamusersRecord> teamusersRecordList, ProjectsRecord newProject) {
         ArrayList<ProjectusersRecord> newProjectUsers = new ArrayList<>(teamusersRecordList.size());

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TaskRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TaskRepository.java
@@ -5,6 +5,9 @@ import org.jooq.DSLContext;
 import org.jooq.Record2;
 import org.opm.busybeaver.dto.Tasks.NewTaskDto;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
+import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
+import org.opm.busybeaver.enums.ErrorMessageConstants;
+import org.opm.busybeaver.exceptions.Tasks.TasksExceptions;
 import org.opm.busybeaver.jooq.tables.records.TasksRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -13,15 +16,20 @@ import org.springframework.stereotype.Repository;
 import java.time.LocalDateTime;
 
 import static org.jooq.impl.DSL.count;
+import static org.opm.busybeaver.jooq.Tables.*;
 import static org.opm.busybeaver.jooq.tables.Tasks.TASKS;
 
 @Repository
 @Component
 public class TaskRepository {
     private final DSLContext create;
+    private final CommentRepository commentRepository;
 
     @Autowired
-    public TaskRepository(DSLContext dslContext) { this.create = dslContext; }
+    public TaskRepository(DSLContext dslContext, CommentRepository commentRepository) {
+        this.create = dslContext;
+        this.commentRepository = commentRepository;
+    }
 
     public TaskCreatedDto addTask(NewTaskDto newTaskDto, int projectID) {
         // INSERT INTO Tasks (title, description, project_id, column_id, assigned_to, sprint_id, priority, due_date)
@@ -55,6 +63,56 @@ public class TaskRepository {
                         TASKS.SPRINT_ID,
                         TASKS.ASSIGNED_TO)
                 .fetchSingleInto(TaskCreatedDto.class);
+    }
+
+    public TaskDetailsDto getTaskDetails(int taskID) throws TasksExceptions.TaskDoesNotExistInProject {
+        // SELECT Tasks.task_id, Tasks.title, Tasks.description,
+        //      Tasks.priority, Columns.columns_id, Columns.column_title,
+        //      Columns.column_index, ProjectUsers.user_id, BeaverUsers.username,
+        //      Sprints.sprint_id, Sprints.begin_date, Sprints.end_date, Sprints.sprint_name
+        // FROM Tasks
+        // JOIN Columns
+        // ON Tasks.column_id = Columns.column_id
+        // JOIN ProjectUsers
+        // ON Tasks.assigned_to = ProjectUsers.user_project_id
+        // JOIN BeaverUsers
+        // ON BeaverUsers.user_id = ProjectUsers.user_id
+        // JOIN Sprints
+        // ON Tasks.sprint_id = Sprints.sprint_id
+        // WHERE Tasks.task_id = taskID;
+        @Nullable TaskDetailsDto task = create.select(
+                TASKS.TASK_ID,
+                TASKS.TITLE,
+                TASKS.DESCRIPTION,
+                TASKS.PRIORITY,
+                COLUMNS.COLUMN_ID,
+                COLUMNS.COLUMN_TITLE,
+                COLUMNS.COLUMN_INDEX,
+                PROJECTUSERS.USER_ID,
+                BEAVERUSERS.USERNAME,
+                SPRINTS.SPRINT_ID,
+                SPRINTS.BEGIN_DATE,
+                SPRINTS.END_DATE,
+                SPRINTS.SPRINT_NAME)
+                .from(TASKS)
+                .join(COLUMNS)
+                .on(TASKS.COLUMN_ID.eq(COLUMNS.COLUMN_ID))
+                .leftJoin(PROJECTUSERS)
+                .on(TASKS.ASSIGNED_TO.eq(PROJECTUSERS.USER_PROJECT_ID))
+                .leftJoin(BEAVERUSERS)
+                .on(PROJECTUSERS.USER_ID.eq(BEAVERUSERS.USER_ID))
+                .leftJoin(SPRINTS)
+                .on(TASKS.SPRINT_ID.eq(SPRINTS.SPRINT_ID))
+                .where(TASKS.TASK_ID.eq(taskID))
+                .fetchOneInto(TaskDetailsDto.class);
+
+        if (task == null) {
+            throw new TasksExceptions.TaskDoesNotExistInProject(ErrorMessageConstants.TASK_NOT_IN_PROJECT.getValue());
+        }
+
+        task.setComments(commentRepository.getCommentsOnTask(taskID));
+
+        return task;
     }
 
     public TasksRecord doesTaskExistInProject(int taskID, int projectID) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TaskRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TaskRepository.java
@@ -1,9 +1,10 @@
 package org.opm.busybeaver.repository;
 
+import org.jetbrains.annotations.Nullable;
 import org.jooq.DSLContext;
+import org.jooq.Record2;
 import org.opm.busybeaver.dto.Tasks.NewTaskDto;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
-import org.opm.busybeaver.jooq.tables.Tasks;
 import org.opm.busybeaver.jooq.tables.records.TasksRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -11,7 +12,7 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 
-import static org.opm.busybeaver.jooq.Tables.COLUMNS;
+import static org.jooq.impl.DSL.count;
 import static org.opm.busybeaver.jooq.tables.Tasks.TASKS;
 
 @Repository
@@ -65,6 +66,24 @@ public class TaskRepository {
                         .where(TASKS.TASK_ID.eq(taskID))
                         .and(TASKS.PROJECT_ID.eq(projectID))
                         .fetchOne();
+    }
+
+    public Boolean doesProjectHaveZeroTasks(int projectID) {
+        // SELECT Tasks.project_id, COUNT(*)
+        // FROM Tasks
+        // WHERE Tasks.project_id = projectID
+        // GROUP BY Tasks.project_Id
+        @Nullable Record2<Integer, Integer> countOfTasksInProject = create.select(TASKS.PROJECT_ID, count())
+                .from(TASKS)
+                .where(TASKS.PROJECT_ID.eq(projectID))
+                .groupBy(TASKS.PROJECT_ID)
+                .fetchOne();
+
+        if (countOfTasksInProject == null) {
+            return true;
+        }
+
+        return (countOfTasksInProject.value2() == 0);
     }
 
     public Boolean doesTaskExistInColumnInProject(int projectID, int columnID) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TaskService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TaskService.java
@@ -2,6 +2,7 @@ package org.opm.busybeaver.service;
 
 import org.opm.busybeaver.dto.Tasks.NewTaskDto;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
+import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.DatabaseConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
@@ -86,6 +87,20 @@ public class TaskService implements ValidateUserAndProjectInterface {
         projectRepository.updateLastUpdatedForProject(projectID);
         return taskCreatedDto;
     }
+
+    public TaskDetailsDto getTaskDetails(UserDto userDto, int projectID, int taskID, String contextPath)
+            throws UsersExceptions.UserDoesNotExistException,
+                ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException
+    {
+        // Validate user, and user in valid project
+        validateUserValidAndInsideValidProject(userDto, projectID);
+
+        TaskDetailsDto taskDetailsDto = taskRepository.getTaskDetails(taskID);
+        taskDetailsDto.setTaskLocation(contextPath, projectID);
+
+        return taskDetailsDto;
+    }
+
     public void moveTask(UserDto userDto, int projectID, int taskID, int columnID)
             throws UsersExceptions.UserDoesNotExistException,
             ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException,


### PR DESCRIPTION
Ready for review!
~~NOTE: Won't merge this one until #54 is complete~~ 

Another batch of routes, related to a project page that a user visits.

`/api/v1/projects/{projectID}` - DELETE

> Allows a user to delete a project.
> Project must have no more tasks associated with.
> Must provide a real projectID the user is a member of.

`/api/v1/projects/{projectID}/tasks/{taskID}` - GET

> Gets specific task details, including comments.
> Task must exist within project.
> Must provide a real projectID the user is a member of.

NOTE: For all of these, the Project `last_updated` field will NOT be updated accordingly.

Can test locally using Postman or another API simulator. You will need to grab an authentication token after signing into the Firebase authentication service. This token will need to be placed in the Authentication: Bearer {TOKEN} header.

You can then make calls to the API locally using this setup. You may need to insert mock data into the database to get actual results.

Closes #51 