### PR TITLE
Modify Task, Modify Project Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,4 @@ Gives little demo or visual representation of project
 ![](my_video.mov)
 
 ## API Reference
-Our API documentation is kept [here](backend/API_Documentation.md)
+Our API documentation is kept [here](backend/README.md)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.Projects.NewProjectDto;
+import org.opm.busybeaver.dto.Projects.NewProjectNameDto;
 import org.opm.busybeaver.dto.Projects.ProjectDetailsDto;
 import org.opm.busybeaver.dto.Projects.ProjectsSummariesDto;
 import org.opm.busybeaver.dto.SmallJsonResponse;
@@ -72,6 +73,19 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         return projectsService.getSpecificProjectDetails(userDto, projectID, request.getContextPath());
+    }
+
+    @PutMapping(PROJECTS_PATH +"/{projectID}")
+    public SmallJsonResponse modifyProjectName(
+            @PathVariable int projectID,
+            @Valid @RequestBody NewProjectNameDto newProjectNameDto,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        projectsService.modifyProjectName(userDto, projectID, newProjectNameDto);
+        return new SmallJsonResponse(
+                HttpStatus.OK.value(),
+                SuccessMessageConstants.PROJECT_NAME_MODIFIED.getValue()
+        );
     }
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
@@ -1,10 +1,12 @@
 package org.opm.busybeaver.controller;
 
+import com.google.api.Http;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.SmallJsonResponse;
+import org.opm.busybeaver.dto.Tasks.EditTaskDto;
 import org.opm.busybeaver.dto.Tasks.NewTaskDtoExtended;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
 import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
@@ -16,6 +18,8 @@ import org.opm.busybeaver.service.TasksService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
 
 @ApiPrefixController
 @RestController
@@ -64,6 +68,27 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
         tasksService.moveTask(userDto, projectID, taskID, columnID);
 
         return new SmallJsonResponse(HttpStatus.OK.value(), SuccessMessageConstants.TASK_MOVED.getValue());
+    }
+
+    @PutMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")
+    public SmallJsonResponse modifyTask(
+            @PathVariable int projectID,
+            @PathVariable int taskID,
+            @Valid @RequestBody Map<String, Object> editTaskData,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        // Including the
+        if (tasksService.modifyTask(userDto, projectID, taskID, editTaskData)) {
+           return new SmallJsonResponse(
+                   HttpStatus.OK.value(),
+                   SuccessMessageConstants.TASK_MODIFIED.getValue()
+           );
+        }
+
+        return new SmallJsonResponse(
+                HttpStatus.OK.value(),
+                SuccessMessageConstants.TASK_NOT_MODIFIED.getValue()
+        );
     }
 
     @DeleteMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Columns/NewColumnTitleDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Columns/NewColumnTitleDto.java
@@ -4,7 +4,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
 public record NewColumnTitleDto(
-        @NotBlank(message = "Column names must be 3 to 50 characters")
+        @NotBlank(message = "Missing 'columnTitle' attribute to modify column title")
         @Size(min = 3, max = 50, message = "Column names must be 3 to 50 characters")
         String columnTitle
 ) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Projects/NewProjectDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Projects/NewProjectDto.java
@@ -9,7 +9,7 @@ import org.opm.busybeaver.enums.BusyBeavPaths;
 public final class NewProjectDto implements ProjectBasicInterface, TeamInterface {
 
     @NotBlank(message = "Missing 'projectName' attribute to generate a new project")
-    @Size(min = 3, max = 50, message = "Project name must be between 3 and 50 characters")
+    @Size(min = 3, max = 50, message = "Project name must be 3 and 50 characters")
     private final String projectName;
 
     @NotBlank(message = "Missing 'teamName' attribute to generate a new project")

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Projects/NewProjectNameDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Projects/NewProjectNameDto.java
@@ -1,0 +1,10 @@
+package org.opm.busybeaver.dto.Projects;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record NewProjectNameDto (
+    @NotBlank(message = "Missing 'projectName' attribute to modify project name")
+    @Size(min = 3, max = 50, message = "Project names must be 3 to 50 characters")
+    String projectName
+) { }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/EditTaskDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/EditTaskDto.java
@@ -1,0 +1,64 @@
+package org.opm.busybeaver.dto.Tasks;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.opm.busybeaver.annotations.TaskPriorityValidation;
+
+import javax.annotation.Nullable;
+import java.time.LocalDate;
+import java.util.Optional;
+
+public final class EditTaskDto {
+    private final String title;
+
+    private String description;
+    @Nullable
+    private final LocalDate dueDate;
+    @TaskPriorityValidation()
+    private final String priority;
+    @Nullable
+    private final Integer sprintID;
+    @Nullable
+    private final Integer assignedTo;
+
+    @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
+    private final int columnID;
+
+    public EditTaskDto(String title, @Nullable String description, @Nullable LocalDate dueDate, String priority, @Nullable Integer sprintID, @Nullable Integer assignedTo, int columnID) {
+        this.title = title;
+        this.description = description;
+        this.dueDate = dueDate;
+        this.priority = priority;
+        this.sprintID = sprintID;
+        this.assignedTo = assignedTo;
+        this.columnID = columnID;
+    }
+
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public String getPriority() {
+        return priority;
+    }
+
+    public Integer getSprintID() {
+        return sprintID;
+    }
+
+    public Integer getAssignedTo() {
+        return assignedTo;
+    }
+
+    public Integer getColumnID() {
+        return columnID;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/NewTaskDtoExtended.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/NewTaskDtoExtended.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 
 public final class NewTaskDtoExtended implements TaskExtendedInterface {
 
-    @NotBlank(message = "Missing 'username' attribute to make a new user")
+    @NotBlank(message = "Missing 'title' attribute to make a new task")
     @Size(min = 3, max = 100, message = "Task title must be 3 to 100 characters")
     private final String title;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
@@ -19,6 +19,7 @@ public enum ErrorMessageConstants {
     TEAM_CREATOR_CANNOT_BE_REMOVED("Team creator cannot be removed"),
     PROJECT_ALREADY_EXISTS_FOR_TEAM("Project name for that team already exists, please choose another project name"),
     USER_NOT_IN_PROJECT_OR_PROJECT_NOT_EXIST("User not in project, or project does not exist"),
+    ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST("Assigned-To user not in project, or user does not exist"),
     TEAM_STILL_HAS_PROJECTS("Team still has associated projects - remove them before deleting the team"),
     COLUMN_NOT_IN_PROJECT("Given column does not exist in this project"),
     COLUMN_TITLE_ALREADY_IN_PROJECT("Given column title already exists in this project"),
@@ -38,7 +39,12 @@ public enum ErrorMessageConstants {
     COLUMN_INDEX_OUT_OF_BOUNDS("Column index given is out of bounds for the given project"),
     COLUMN_TITLE_EQUIVALENT_NOT_MODIFIED("Column title not changed, title identical to previous"),
     SPRINT_DATES_INVALID("Sprint dates are invalid"),
-    PROJECT_CONTAINS_SPRINT_NAME("Project contains sprint with that name already");
+    PROJECT_CONTAINS_SPRINT_NAME("Project contains sprint with that name already"),
+    TASK_FIELD_NOT_FOUND("Task field to modify not valid"),
+    TASK_PRIORITY_INVALID("Task priority invalid"),
+    TASK_DUE_DATE_INVALID("Task due date invalid"),
+    TASK_TITLE_INVALID("Title length must be a string from 3 to 50 characters"),
+    TASK_DESCRIPTION_INVALID("Title description must be a string up to 500 characters long");
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
@@ -44,7 +44,8 @@ public enum ErrorMessageConstants {
     TASK_PRIORITY_INVALID("Task priority invalid"),
     TASK_DUE_DATE_INVALID("Task due date invalid"),
     TASK_TITLE_INVALID("Title length must be a string from 3 to 50 characters"),
-    TASK_DESCRIPTION_INVALID("Title description must be a string up to 500 characters long");
+    TASK_DESCRIPTION_INVALID("Title description must be a string up to 500 characters long"),
+    PROJECT_NAME_EQUIVALENT_NOT_MODIFIED("Project name not changed, name identical to previous");
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
@@ -13,7 +13,9 @@ public enum SuccessMessageConstants {
     PROJECT_DELETED("Project deleted"),
     COMMENT_MODIFIED("Comment modified"),
     COMMENT_DELETED("Comment deleted"),
-    SPRINT_DELETED("Sprint deleted"); // Place username in front
+    SPRINT_DELETED("Sprint deleted"),
+    TASK_MODIFIED("Task successfully modified"),
+    TASK_NOT_MODIFIED("Task was not modified"); // Place username in front
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
@@ -15,7 +15,8 @@ public enum SuccessMessageConstants {
     COMMENT_DELETED("Comment deleted"),
     SPRINT_DELETED("Sprint deleted"),
     TASK_MODIFIED("Task successfully modified"),
-    TASK_NOT_MODIFIED("Task was not modified"); // Place username in front
+    TASK_NOT_MODIFIED("Task was not modified"),
+    PROJECT_NAME_MODIFIED("Project name was modified"); // Place username in front
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/TaskFields.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/TaskFields.java
@@ -1,0 +1,26 @@
+package org.opm.busybeaver.enums;
+
+import org.springframework.util.ObjectUtils;
+
+import java.util.Map;
+
+public enum TaskFields {
+    title, description, dueDate, assignedTo, priority, sprintID, customFields;
+
+    public enum priorityFields {
+        None, Low, High, Medium;
+
+        public static boolean isPriorityFieldValid(String priority) {
+            return ObjectUtils.containsConstant(priorityFields.values(), priority, true);
+        }
+    }
+
+    public static boolean areTaskFieldsValid(Map<String, Object> fieldsToCheck) {
+        for (String key : fieldsToCheck.keySet()) {
+            boolean containsValidField = ObjectUtils.containsConstant(TaskFields.values(), key, true);
+
+            if (!containsValidField) return false;
+        }
+        return true;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ProjectUsers/ProjectUsersExceptionHandler.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ProjectUsers/ProjectUsersExceptionHandler.java
@@ -42,4 +42,15 @@ public class ProjectUsersExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
+
+    @ExceptionHandler(ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent.class)
+    public ResponseEntity<?> assignedToNotInProjectOrNonexistent() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue(),
+                        HttpStatus.NOT_FOUND.value()
+                ),
+                HttpStatus.NOT_FOUND
+        );
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ProjectUsers/ProjectUsersExceptions.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ProjectUsers/ProjectUsersExceptions.java
@@ -19,4 +19,10 @@ public final class ProjectUsersExceptions {
             super(errorMessage);
         }
     }
+
+    public static class AssignedToUserNotInProjectOrNonexistent extends RuntimeException {
+        public AssignedToUserNotInProjectOrNonexistent(String errorMessage) {
+            super(errorMessage);
+        }
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptionHandler.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptionHandler.java
@@ -42,4 +42,15 @@ public class ProjectsExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
+
+    @ExceptionHandler(ProjectsExceptions.ProjectNameIdenticalToPrevious.class)
+    public ResponseEntity<?> projectNameIdenticalToPrevious() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.PROJECT_NAME_EQUIVALENT_NOT_MODIFIED.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptions.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Projects/ProjectsExceptions.java
@@ -18,4 +18,10 @@ public final class ProjectsExceptions {
             super(errorMessage);
         }
     }
+
+    public static class ProjectNameIdenticalToPrevious extends RuntimeException {
+        public ProjectNameIdenticalToPrevious(String errorMessage) {
+            super(errorMessage);
+        }
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Tasks/TasksExceptionHandler.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Tasks/TasksExceptionHandler.java
@@ -31,4 +31,59 @@ public class TasksExceptionHandler {
                 HttpStatus.BAD_REQUEST
         );
     }
+
+    @ExceptionHandler(TasksExceptions.TaskFieldNotFound.class)
+    public ResponseEntity<?> taskFieldNotFound() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.TASK_FIELD_NOT_FOUND.getValue(),
+                        HttpStatus.NOT_FOUND.value()
+                ),
+                HttpStatus.NOT_FOUND
+        );
+    }
+
+    @ExceptionHandler(TasksExceptions.InvalidTaskPriority.class)
+    public ResponseEntity<?> taskInvalidPriority() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.TASK_PRIORITY_INVALID.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(TasksExceptions.InvalidTaskDueDate.class)
+    public ResponseEntity<?> taskInvalidDueDate() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(TasksExceptions.InvalidTaskTitle.class)
+    public ResponseEntity<?> taskInvalidTitleLength() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.TASK_TITLE_INVALID.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
+
+    @ExceptionHandler(TasksExceptions.InvalidTaskDescription.class)
+    public ResponseEntity<?> taskInvalidDescriptionLength() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.TASK_DESCRIPTION_INVALID.getValue(),
+                        HttpStatus.BAD_REQUEST.value()
+                ),
+                HttpStatus.BAD_REQUEST
+        );
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Tasks/TasksExceptions.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/Tasks/TasksExceptions.java
@@ -11,4 +11,24 @@ public final class TasksExceptions {
     public static class TaskAlreadyInColumn extends RuntimeException {
         public TaskAlreadyInColumn(String errorMessage) { super(errorMessage); }
     }
+
+    public static class TaskFieldNotFound extends RuntimeException {
+        public TaskFieldNotFound(String errorMessage) { super(errorMessage); }
+    }
+
+    public static class InvalidTaskPriority extends RuntimeException {
+        public InvalidTaskPriority(String errorMessage) { super(errorMessage); }
+    }
+
+    public static class InvalidTaskDueDate extends RuntimeException {
+        public InvalidTaskDueDate(String errorMessage) { super(errorMessage); }
+    }
+
+    public static class InvalidTaskTitle extends RuntimeException {
+        public InvalidTaskTitle(String errorMessage) { super(errorMessage); }
+    }
+
+    public static class InvalidTaskDescription extends RuntimeException {
+        public InvalidTaskDescription(String errorMessage) { super(errorMessage); }
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
@@ -2,6 +2,7 @@ package org.opm.busybeaver.repository;
 
 import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
+import org.jooq.exception.NoDataFoundException;
 import org.opm.busybeaver.dto.Columns.NewColumnDto;
 import org.opm.busybeaver.enums.DefaultColumnNames;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
@@ -129,12 +130,18 @@ public class ColumnsRepository {
                     .set(COLUMNS.COLUMN_TITLE, newColumnTitle)
                     .where(COLUMNS.PROJECT_ID.eq(projectID))
                     .and(COLUMNS.COLUMN_ID.eq(columnID))
+                    .and(COLUMNS.COLUMN_TITLE.ne(newColumnTitle))
                     .returningResult(COLUMNS.COLUMN_TITLE, COLUMNS.COLUMN_INDEX, COLUMNS.COLUMN_ID)
                     .fetchSingleInto(NewColumnDto.class);
 
         } catch (DuplicateKeyException e) {
             throw new ColumnsExceptions.ColumnTitleAlreadyInProject(
                     ErrorMessageConstants.COLUMN_TITLE_ALREADY_IN_PROJECT.getValue());
+
+        } catch (NoDataFoundException e) {
+            throw new ColumnsExceptions.ColumnTitleIdentical(
+                    ErrorMessageConstants.COLUMN_TITLE_EQUIVALENT_NOT_MODIFIED.getValue()
+            );
         }
 
     }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
@@ -4,6 +4,7 @@ import org.jooq.DSLContext;
 import org.opm.busybeaver.dto.ProjectUsers.ProjectUserSummaryDto;
 import org.opm.busybeaver.dto.Users.UserSummaryDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
+import org.opm.busybeaver.exceptions.ProjectUsers.ProjectUsersExceptions;
 import org.opm.busybeaver.exceptions.Projects.ProjectsExceptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -93,5 +94,24 @@ public class ProjectUsersRepository {
                     ErrorMessageConstants.USER_NOT_IN_PROJECT_OR_PROJECT_NOT_EXIST.getValue());
         }
         return true;
+    }
+
+    public void isAssignedToUserInProject(int userID, int projectID)
+            throws ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException {
+        // SELECT EXISTS(
+        //      SELECT ProjectUsers.project_id,ProjectUsers.user_id
+        //      FROM ProjectUsers
+        //      WHERE ProjectUsers.project_id = projectID
+        //      AND ProjectUsers.user_id = userID
+        boolean isValidUserInValidProject = create.fetchExists(
+                create.selectFrom(PROJECTUSERS)
+                        .where(PROJECTUSERS.PROJECT_ID.eq(projectID))
+                        .and(PROJECTUSERS.USER_ID.eq(userID))
+        );
+
+        if (!isValidUserInValidProject) {
+            throw new ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent(
+                    ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue());
+        }
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectsRepository.java
@@ -226,6 +226,19 @@ public class ProjectsRepository {
         return projectAndTeam;
     }
 
+    public void modifyProjectName(int projectID, String newProjectName)
+        throws ProjectsExceptions.ProjectNameIdenticalToPrevious {
+        int rowsChanged = create.update(PROJECTS)
+                .set(PROJECTS.PROJECT_NAME, newProjectName)
+                .where(PROJECTS.PROJECT_ID.eq(projectID))
+                .and(PROJECTS.PROJECT_NAME.ne(newProjectName))
+                .execute();
+        if (rowsChanged == 0) {
+            throw new ProjectsExceptions.ProjectNameIdenticalToPrevious(
+                    ErrorMessageConstants.PROJECT_NAME_EQUIVALENT_NOT_MODIFIED.getValue());
+        }
+    }
+
     private void setColumnTasks(List<ColumnDto> columns, @Nullable List<TaskBasicDto> tasks) {
         if (tasks == null) return;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TasksRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TasksRepository.java
@@ -8,6 +8,7 @@ import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
 import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Tasks.TasksExceptions;
+import org.opm.busybeaver.jooq.tables.records.TasksRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
@@ -115,21 +116,22 @@ public class TasksRepository {
         return task;
     }
 
-    public void doesTaskExistInProject(int taskID, int projectID) throws TasksExceptions.TaskDoesNotExistInProject {
-        // SELECT EXISTS (
-        //      SELECT Tasks.task_id
-        //      FROM Tasks
-        //      WHERE Tasks.task_id = taskID
-        //      AND Tasks.project_id = projectID);
-        boolean taskInProject = create.fetchExists(
-                create.select(TASKS.TASK_ID)
-                        .from(TASKS)
+    public TasksRecord doesTaskExistInProject(int taskID, int projectID)
+            throws TasksExceptions.TaskDoesNotExistInProject {
+        // SELECT Tasks.task_id
+        // FROM Tasks
+        // WHERE Tasks.task_id = taskID
+        // AND Tasks.project_id = projectID);
+        TasksRecord taskInProject =
+                create.selectFrom(TASKS)
                         .where(TASKS.TASK_ID.eq(taskID))
-                        .and(TASKS.PROJECT_ID.eq(projectID)));
+                        .and(TASKS.PROJECT_ID.eq(projectID)).fetchOneInto(TasksRecord.class);
 
-        if (!taskInProject) {
+
+        if (taskInProject == null) {
             throw new TasksExceptions.TaskDoesNotExistInProject(ErrorMessageConstants.TASK_NOT_IN_PROJECT.getValue());
         }
+        return taskInProject;
     }
 
     public Boolean doesProjectHaveZeroTasks(int projectID) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ColumnsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ColumnsService.java
@@ -121,13 +121,7 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         // Validate column exists in project
-        ColumnsRecord columnInProject = columnsRepository.doesColumnExistInProject(columnID, projectID);
-        String currentColumnTitle = columnInProject.getColumnTitle();
-
-        if (currentColumnTitle.equals(newColumnTitleDto.columnTitle())) {
-            throw new ColumnsExceptions.ColumnTitleIdentical(
-                    ErrorMessageConstants.COLUMN_TITLE_EQUIVALENT_NOT_MODIFIED.getValue());
-        }
+        columnsRepository.doesColumnExistInProject(columnID, projectID);
 
         NewColumnDto changedColumn = columnsRepository.changeColumnTitle(
                 projectID,

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectsService.java
@@ -1,9 +1,6 @@
 package org.opm.busybeaver.service;
 
-import org.opm.busybeaver.dto.Projects.NewProjectDto;
-import org.opm.busybeaver.dto.Projects.ProjectDetailsDto;
-import org.opm.busybeaver.dto.Projects.ProjectSummaryDto;
-import org.opm.busybeaver.dto.Projects.ProjectsSummariesDto;
+import org.opm.busybeaver.dto.Projects.*;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Projects.ProjectsExceptions;
@@ -92,6 +89,13 @@ public final class ProjectsService implements ValidateUserAndProjectInterface {
         projectDetails.setLocations(contextPath);
 
         return projectDetails;
+    }
+
+    public void modifyProjectName(UserDto userDto, int projectID, NewProjectNameDto newProjectNameDto) {
+        validateUserValidAndInsideValidProject(userDto, projectID);
+        String newProjectName = newProjectNameDto.projectName();
+        projectsRepository.modifyProjectName(projectID, newProjectName);
+        projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
     @Override

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
@@ -1,15 +1,30 @@
 package org.opm.busybeaver.service;
 
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Tasks.NewTaskDtoExtended;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
 import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.DatabaseConstants;
+import org.opm.busybeaver.enums.ErrorMessageConstants;
+import org.opm.busybeaver.enums.TaskFields;
+import org.opm.busybeaver.exceptions.ProjectUsers.ProjectUsersExceptions;
+import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
+import org.opm.busybeaver.exceptions.Tasks.TasksExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
+import org.opm.busybeaver.jooq.tables.records.TasksRecord;
 import org.opm.busybeaver.repository.*;
 import org.opm.busybeaver.service.ServiceInterfaces.ValidateUserAndProjectInterface;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.util.ObjectUtils;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.EnumSet;
+import java.util.Map;
+
 
 @Service
 public class TasksService implements ValidateUserAndProjectInterface {
@@ -55,7 +70,7 @@ public class TasksService implements ValidateUserAndProjectInterface {
 
         // If assignedTo, validate user exists in Project
         if (newTaskDto.getAssignedTo() != null) {
-            projectUsersRepository.isUserInProjectAndDoesProjectExist(newTaskDto.getAssignedTo(), projectID);
+            projectUsersRepository.isAssignedToUserInProject(newTaskDto.getAssignedTo(), projectID);
         }
 
         // If sprint, validate sprint exists in project
@@ -107,6 +122,34 @@ public class TasksService implements ValidateUserAndProjectInterface {
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
+    public boolean modifyTask(UserDto userDto, int projectID, int taskID, Map<String, Object> fieldsToEdit)
+        throws TasksExceptions.TaskFieldNotFound {
+
+        if (fieldsToEdit.isEmpty()) return false;
+
+        validateUserValidAndInsideValidProject(userDto, projectID);
+
+        if (!TaskFields.areTaskFieldsValid(fieldsToEdit)) {
+            throw new TasksExceptions.TaskFieldNotFound(ErrorMessageConstants.TASK_FIELD_NOT_FOUND.getValue());
+        }
+
+        TasksRecord taskToEdit = tasksRepository.doesTaskExistInProject(taskID, projectID);
+
+        modifyTaskPriority(taskToEdit, fieldsToEdit);
+        modifyTaskDueDate(taskToEdit, fieldsToEdit);
+        modifyTaskSprintID(taskToEdit, fieldsToEdit, projectID);
+        modifyTaskAssignedTo(taskToEdit, fieldsToEdit, projectID);
+        modifyTaskDescription(taskToEdit, fieldsToEdit);
+        modifyTaskTitle(taskToEdit, fieldsToEdit);
+
+        boolean taskUpdated = taskToEdit.changed();
+        if (taskUpdated) {
+            taskToEdit.update();
+        }
+
+        return taskUpdated;
+    }
+
     public void deleteTask(UserDto userDto, int projectID, int taskID) {
         // Validate user exists, is in project and project exists
         validateUserValidAndInsideValidProject(userDto, projectID);
@@ -119,6 +162,144 @@ public class TasksService implements ValidateUserAndProjectInterface {
 
         // Update project last updated time
         projectsRepository.updateLastUpdatedForProject(projectID);
+    }
+
+    private void modifyTaskPriority(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+        throws TasksExceptions.InvalidTaskPriority {
+
+        final String PRIORITY = TaskFields.priority.toString();
+        if (fieldsToEdit.containsKey(PRIORITY) && fieldsToEdit.get(PRIORITY) != null) {
+
+            if (!TaskFields.priorityFields.isPriorityFieldValid(fieldsToEdit.get(PRIORITY).toString())) {
+                throw new TasksExceptions.InvalidTaskPriority(ErrorMessageConstants.TASK_PRIORITY_INVALID.getValue());
+            }
+
+            if (taskToEdit.getPriority() == null || !taskToEdit.getPriority().equals(fieldsToEdit.get(PRIORITY).toString())) {
+                taskToEdit.setPriority(fieldsToEdit.get(PRIORITY).toString());
+            }
+        }
+    }
+
+    private void modifyTaskDueDate(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+        throws TasksExceptions.InvalidTaskDueDate {
+        // Task due date can be set to NULL, indicated by incoming JSON field for dueDate being set to null
+
+        final String DUE_DATE = TaskFields.dueDate.toString();
+        if (fieldsToEdit.containsKey(DUE_DATE)) {
+            if (fieldsToEdit.get(DUE_DATE) != null) {
+                DateTimeFormatter dueDateFormat = DateTimeFormatter.ISO_LOCAL_DATE;
+                try {
+                    LocalDate dueDate = LocalDate.parse(fieldsToEdit.get(DUE_DATE).toString(), dueDateFormat);
+                    if (dueDate.isBefore(LocalDate.now())) {
+                        throw new TasksExceptions.InvalidTaskDueDate(
+                                ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+                    }
+
+                    if (taskToEdit.getDueDate() == null || !taskToEdit.getDueDate().isEqual(dueDate)) {
+                        taskToEdit.setDueDate(dueDate);
+                    }
+
+                } catch (DateTimeParseException dateTimeParseException) {
+                    throw new TasksExceptions.InvalidTaskDueDate(
+                            ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+                }
+            } else {
+                if (taskToEdit.getDueDate() != null) {
+                    taskToEdit.setDueDate(null);
+                }
+            }
+        }
+    }
+
+    private void modifyTaskSprintID(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit, int projectID)
+        throws SprintsExceptions.SprintDoesNotExistInProject {
+        // Task sprintID can be set to NULL, indicated by incoming JSON field for sprintID being set to null
+
+        final String SPRINT_ID = TaskFields.sprintID.toString();
+        if (fieldsToEdit.containsKey(SPRINT_ID)) {
+            if (fieldsToEdit.get(SPRINT_ID) != null) {
+                try {
+                    int sprintID = Integer.parseInt(fieldsToEdit.get(SPRINT_ID).toString());
+                    sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+
+                    if (taskToEdit.getSprintId() == null || !taskToEdit.getSprintId().equals(sprintID)) {
+                        taskToEdit.setSprintId(sprintID);
+                    }
+
+                } catch (IllegalArgumentException illegalArgumentException) {
+                    throw new SprintsExceptions.SprintDoesNotExistInProject(ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue());
+                }
+            } else {
+                if (taskToEdit.getSprintId() != null) {
+                    taskToEdit.setSprintId(null);
+                }
+            }
+        }
+    }
+
+    private void modifyTaskDescription(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+        throws TasksExceptions.InvalidTaskDescription {
+        // Task description can be set to NULL, indicated by incoming JSON field for description being set to null
+
+        final String DESCRIPTION = TaskFields.description.toString();
+        if (fieldsToEdit.containsKey(DESCRIPTION)) {
+            Object description = fieldsToEdit.get(DESCRIPTION);
+            if (description != null) {
+                if (!(description instanceof String) || (((String) description).length() > 500)) {
+                    throw new TasksExceptions.InvalidTaskDescription(ErrorMessageConstants.TASK_DESCRIPTION_INVALID.getValue());
+                }
+                if (taskToEdit.getDescription() == null || !taskToEdit.getDescription().equals(description)) {
+                    taskToEdit.setDescription((String) description);
+                }
+            } else {
+                if (taskToEdit.getDescription() != null) {
+                    taskToEdit.setDescription(null);
+                }
+            }
+        }
+    }
+
+    private void modifyTaskTitle(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+        throws TasksExceptions.InvalidTaskTitle {
+
+        final String TITLE = TaskFields.title.toString();
+        if (fieldsToEdit.containsKey(TITLE) && fieldsToEdit.get(TITLE) != null) {
+            Object title = fieldsToEdit.get(TITLE);
+            if (!(title instanceof String) || (((((String) title).length() > 50) || ((String) title).length() < 3))) {
+                throw new TasksExceptions.InvalidTaskTitle(ErrorMessageConstants.TASK_TITLE_INVALID.getValue());
+            }
+
+            if (!taskToEdit.getTitle().equals(title)) {
+                taskToEdit.setTitle((String) title);
+            }
+        }
+    }
+
+    private void modifyTaskAssignedTo(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit, int projectID)
+        throws ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent {
+        // Task assignedTo can be set to NULL, indicated by incoming JSON field for assignedTo being set to null
+
+        final String ASSIGNED_TO = TaskFields.assignedTo.toString();
+        if (fieldsToEdit.containsKey(ASSIGNED_TO)) {
+            if (fieldsToEdit.get(ASSIGNED_TO) != null) {
+                try {
+                    int assignedToID = Integer.parseInt(fieldsToEdit.get(ASSIGNED_TO).toString());
+                    projectUsersRepository.isAssignedToUserInProject(assignedToID, projectID);
+
+                    if (taskToEdit.getAssignedTo() == null || !taskToEdit.getAssignedTo().equals(assignedToID)) {
+                        taskToEdit.setAssignedTo(assignedToID);
+                    }
+
+                } catch (IllegalArgumentException illegalArgumentException) {
+                    throw new ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent(
+                            ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue());
+                }
+            } else {
+                if (taskToEdit.getAssignedTo() != null) {
+                    taskToEdit.setAssignedTo(null);
+                }
+            }
+        }
     }
 
     @Override

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
@@ -17,12 +17,10 @@ import org.opm.busybeaver.repository.*;
 import org.opm.busybeaver.service.ServiceInterfaces.ValidateUserAndProjectInterface;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
-import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
-import java.util.EnumSet;
 import java.util.Map;
 
 
@@ -145,6 +143,7 @@ public class TasksService implements ValidateUserAndProjectInterface {
         boolean taskUpdated = taskToEdit.changed();
         if (taskUpdated) {
             taskToEdit.update();
+            projectsRepository.updateLastUpdatedForProject(projectID);
         }
 
         return taskUpdated;


### PR DESCRIPTION
Another batch of routes, related to a project page that a user visits.

`/api/v1/projects/{projectID}/tasks/{taskID}` - PUT

> Allows user to modify the contents of a task, but not the column it is on.
> Fields modifiable include: `title`, `description`, `assignedTo`, `sprintID`, `dueDate`, `priority`
> See API Documentation for details
> Must provide a real projectID the user is a member of, and a real taskID associated with that project.

`/api/v1/projects/{projectID}` - PUT

> Allows a user to modify a project name.
> Must provide a real projectID the user is a member of.
> 3 to 50 character limit on column name.

NOTE: For all of these, the Project `last_updated` field will be updated accordingly.

Can test locally using Postman or another API simulator. You will need to grab an authentication token after signing into the Firebase authentication service. This token will need to be placed in the Authentication: Bearer {TOKEN} header.

You can then make calls to the API locally using this setup. You may need to insert mock data into the database to get actual results.

Closes #58 