### PR TITLE
Get sprints, get sprint tasks, modify sprint

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/annotations/SprintDateValidator.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/annotations/SprintDateValidator.java
@@ -2,24 +2,25 @@ package org.opm.busybeaver.annotations;
 
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
+import org.opm.busybeaver.dto.Interfaces.SprintInterface;
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
 
-public class SprintDateValidator implements ConstraintValidator<SprintDateValidation, NewSprintDto> {
+public class SprintDateValidator implements ConstraintValidator<SprintDateValidation, SprintInterface> {
 
     @Override
     public void initialize(SprintDateValidation sprintDateValidation){}
 
     @Override
-    public boolean isValid(NewSprintDto newSprintDto, ConstraintValidatorContext context) {
+    public boolean isValid(SprintInterface newSprintDto, ConstraintValidatorContext context) {
         if (newSprintDto == null) {
             return true; // Let @NotNull handle null check
         }
 
-        if (newSprintDto.startDate() != null && newSprintDto.endDate() != null &&
-                (newSprintDto.startDate().isAfter(newSprintDto.endDate()) ||
-                        newSprintDto.startDate().isEqual(newSprintDto.endDate()))) {
+        if (newSprintDto.getStartDate() != null && newSprintDto.getEndDate() != null &&
+                (newSprintDto.getStartDate().isAfter(newSprintDto.getEndDate()) ||
+                        newSprintDto.getStartDate().isEqual(newSprintDto.getEndDate()))) {
             throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
         }
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
@@ -8,6 +8,7 @@ import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
 import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
+import org.opm.busybeaver.dto.Sprints.TasksInSprintDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.BusyBeavPaths;
@@ -66,6 +67,16 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         return sprintsService.getAllSprintsForProject(userDto, projectID, request.getContextPath());
+    }
+
+    @GetMapping(PROJECTS_PATH + "/{projectID}" + SPRINT_PATH + "/{sprintID}")
+    public TasksInSprintDto getAllTasksInSprint(
+            HttpServletRequest request,
+            @PathVariable int projectID,
+            @PathVariable int sprintID,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        return sprintsService.getAllTasksInSprint(userDto, projectID, sprintID, request.getContextPath());
     }
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
@@ -5,10 +5,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.SmallJsonResponse;
-import org.opm.busybeaver.dto.Sprints.NewSprintDto;
-import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
-import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
-import org.opm.busybeaver.dto.Sprints.TasksInSprintDto;
+import org.opm.busybeaver.dto.Sprints.*;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.BusyBeavPaths;
@@ -77,6 +74,27 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         return sprintsService.getAllTasksInSprint(userDto, projectID, sprintID, request.getContextPath());
+    }
+
+    @PutMapping(PROJECTS_PATH + "/{projectID}" + SPRINT_PATH + "/{sprintID}")
+    public SmallJsonResponse modifySprint(
+            HttpServletRequest request,
+            @PathVariable int projectID,
+            @PathVariable int sprintID,
+            @Valid @RequestBody EditSprintDto editSprintDto,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        boolean sprintModified = sprintsService.modifySprint(userDto, projectID, sprintID, editSprintDto);
+        if (sprintModified) {
+            return new SmallJsonResponse(
+                    HttpStatus.OK.value(),
+                    SuccessMessageConstants.SPRINT_MODIFIED.getValue()
+            );
+        }
+        return new SmallJsonResponse(
+                HttpStatus.OK.value(),
+                SuccessMessageConstants.SPRINT_NOT_MODIFIED.getValue()
+        );
     }
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
@@ -7,6 +7,7 @@ import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerToken
 import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
+import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.BusyBeavPaths;
@@ -56,6 +57,15 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
                 HttpStatus.OK.value(),
                 SuccessMessageConstants.SPRINT_DELETED.getValue()
         );
+    }
+
+    @GetMapping(PROJECTS_PATH + "/{projectID}" + SPRINT_PATH)
+    public SprintsInProjectDto getAllSprintsForProject(
+            HttpServletRequest request,
+            @PathVariable int projectID,
+            @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
+    ) {
+        return sprintsService.getAllSprintsForProject(userDto, projectID, request.getContextPath());
     }
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/EditSprintDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/EditSprintDto.java
@@ -1,0 +1,51 @@
+package org.opm.busybeaver.dto.Sprints;
+
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Size;
+import org.opm.busybeaver.annotations.SprintDateValidation;
+import org.opm.busybeaver.dto.Interfaces.SprintInterface;
+
+import javax.annotation.Nullable;
+import java.time.LocalDate;
+
+@SprintDateValidation
+public class EditSprintDto implements SprintInterface {
+    @Nullable
+    @Size(min = 3, max = 50, message = "Sprint name must be between 3 and 50 characters")
+    private final String sprintName;
+    @Nullable
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @FutureOrPresent(message = "Start date must be today, or a future date, in the 'yyyy-MM-dd' format")
+    private final LocalDate startDate;
+    @Nullable
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    @Future(message = "End date must be a future date, in the 'yyyy-MM-dd' format")
+    private final LocalDate endDate;
+
+    public EditSprintDto(@Nullable String sprintName, @Nullable LocalDate startDate, @Nullable LocalDate endDate) {
+        this.sprintName = sprintName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    @Nullable
+    @Override
+    public String getSprintName() {
+        return sprintName;
+    }
+
+    @Nullable
+    @Override
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @Nullable
+    @Override
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/SprintsInProjectDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/SprintsInProjectDto.java
@@ -1,0 +1,54 @@
+package org.opm.busybeaver.dto.Sprints;
+
+
+import org.opm.busybeaver.dto.Interfaces.ProjectBasicInterface;
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import java.beans.ConstructorProperties;
+import java.util.List;
+
+public final class SprintsInProjectDto implements ProjectBasicInterface {
+    private final int projectID;
+    private final String projectName;
+    private String projectLocation;
+    private List<SprintSummaryDto> sprints;
+
+    @ConstructorProperties({"project_name", "project_id"})
+    public SprintsInProjectDto(String projectName, int projectID) {
+        this.projectName = projectName;
+        this.projectID = projectID;
+    }
+
+    public void setSprints(List<SprintSummaryDto> sprints) {
+        this.sprints = sprints;
+    }
+
+    @Override
+    public void setLocations(String contextPath) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.projectLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() + "/" + projectID;
+
+        sprints.forEach(sprint -> sprint.setSprintLocation(contextPath, projectID));
+    }
+
+    @Override
+    public String getProjectName() {
+        return projectName;
+    }
+
+    @Override
+    public int getProjectID() {
+        return projectID;
+    }
+
+    @Override
+    public String getProjectLocation() {
+        return projectLocation;
+    }
+
+    public List<SprintSummaryDto> getSprints() {
+        return sprints;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/TasksInSprintDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Sprints/TasksInSprintDto.java
@@ -1,0 +1,68 @@
+package org.opm.busybeaver.dto.Sprints;
+
+import org.opm.busybeaver.dto.Interfaces.SprintInterface;
+import org.opm.busybeaver.dto.Tasks.TaskBasicInSprintDto;
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import java.beans.ConstructorProperties;
+import java.time.LocalDate;
+import java.util.List;
+
+public class TasksInSprintDto implements SprintInterface {
+
+    private final int sprintID;
+    private final String sprintName;
+    private final LocalDate startDate;
+    private final LocalDate endDate;
+    private String sprintLocation;
+    private List<TaskBasicInSprintDto> tasks;
+
+    @ConstructorProperties({"sprint_id", "sprint_name", "begin_date", "end_date"})
+    public TasksInSprintDto(int sprintID, String sprintName, LocalDate startDate, LocalDate endDate) {
+        this.sprintID = sprintID;
+        this.sprintName = sprintName;
+        this.startDate = startDate;
+        this.endDate = endDate;
+    }
+
+    public void setTasks(List<TaskBasicInSprintDto> tasks) {
+        this.tasks = tasks;
+    }
+
+    public void setSprintLocation(String contextPath, int projectID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.sprintLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.SPRINTS.getValue() + "/" + getSprintID();
+
+        tasks.forEach(task -> task.setTaskLocation(contextPath, projectID));
+    }
+
+    public int getSprintID() {
+        return sprintID;
+    }
+
+    @Override
+    public String getSprintName() {
+        return sprintName;
+    }
+
+    @Override
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    @Override
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getSprintLocation() {
+        return sprintLocation;
+    }
+
+    public List<TaskBasicInSprintDto> getTasks() {
+        return tasks;
+    }
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskBasicInSprintDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskBasicInSprintDto.java
@@ -1,0 +1,101 @@
+package org.opm.busybeaver.dto.Tasks;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.opm.busybeaver.dto.Columns.ColumnDto;
+import org.opm.busybeaver.dto.Columns.ColumnInTaskDto;
+import org.opm.busybeaver.dto.Interfaces.TaskBasicInterface;
+import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
+import org.opm.busybeaver.dto.Users.UserSummaryDto;
+import org.opm.busybeaver.enums.BusyBeavPaths;
+
+import javax.annotation.Nullable;
+import java.beans.ConstructorProperties;
+import java.time.LocalDate;
+
+public final class TaskBasicInSprintDto implements TaskBasicInterface {
+    private final String title;
+    private final int taskID;
+    private final String priority;
+    @Nullable
+    private final LocalDate dueDate;
+    private final int comments;
+    private final String description;
+    private ColumnInTaskDto column;
+    @Nullable
+    private UserSummaryDto assignedTo;
+    private String taskLocation;
+
+    @ConstructorProperties({
+            "title", "task_id", "priority", "due_date", "description", "comments",
+            "assigned_to", "username", "column_index", "column_title", "column_id"})
+    public TaskBasicInSprintDto(
+            String title, int taskID, String priority, @Nullable LocalDate dueDate, String description, int comments,
+            @Nullable Integer assignedToId, @Nullable String username,
+            int columnIndex, String columnTitle, int columnID) {
+
+        this.title = title;
+        this.taskID = taskID;
+        this.priority = priority;
+        this.dueDate = dueDate;
+        this.description = description;
+        this.comments = comments;
+
+        this.column = new ColumnInTaskDto(columnTitle, columnID, columnIndex);
+
+        if (assignedToId != null && username != null) {
+            this.assignedTo = new UserSummaryDto(username, assignedToId);
+        }
+    }
+
+    public void setTaskLocation(String contextPath, int projectID) {
+        final String PATH = contextPath + BusyBeavPaths.V1.getValue();
+
+        this.taskLocation = PATH +
+                BusyBeavPaths.PROJECTS.getValue() +
+                "/" + projectID + BusyBeavPaths.TASKS.getValue() + "/" + getTaskID();
+
+        column.setColumnLocation(contextPath, projectID);
+    }
+
+    @Override
+    public String getTitle() {
+        return title;
+    }
+
+    public int getTaskID() {
+        return taskID;
+    }
+
+    @Override
+    public String getPriority() {
+        return priority;
+    }
+
+    @Nullable
+    @Override
+    public LocalDate getDueDate() {
+        return dueDate;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public ColumnInTaskDto getColumn() {
+        return column;
+    }
+
+    @Nullable
+    public UserSummaryDto getAssignedTo() {
+        return assignedTo;
+    }
+
+    public int getComments() {
+        return comments;
+    }
+
+    public String getTaskLocation() {
+        return taskLocation;
+    }
+
+}

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/SuccessMessageConstants.java
@@ -16,7 +16,9 @@ public enum SuccessMessageConstants {
     SPRINT_DELETED("Sprint deleted"),
     TASK_MODIFIED("Task successfully modified"),
     TASK_NOT_MODIFIED("Task was not modified"),
-    PROJECT_NAME_MODIFIED("Project name was modified"); // Place username in front
+    PROJECT_NAME_MODIFIED("Project name was modified"),
+    SPRINT_MODIFIED("Sprint was modified"),
+    SPRINT_NOT_MODIFIED("Sprint was not modified"); // Place username in front
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
@@ -6,10 +6,10 @@ import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
 import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
 import org.opm.busybeaver.dto.Sprints.TasksInSprintDto;
-import org.opm.busybeaver.dto.Tasks.TaskBasicDto;
 import org.opm.busybeaver.dto.Tasks.TaskBasicInSprintDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
+import org.opm.busybeaver.jooq.tables.records.SprintsRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
@@ -66,23 +66,23 @@ public class SprintsRepository {
                 .execute();
     }
 
-    public void doesSprintExistInProject(int sprintID, int projectID)
+    public SprintsRecord doesSprintExistInProject(int sprintID, int projectID)
             throws SprintsExceptions.SprintDoesNotExistInProject {
-        // SELECT EXISTS(
-        //      SELECT *
-        //      FROM Sprints
-        //      WHERE Sprint.sprint_id = sprintID
-        //      AND Sprint.project_id = projectID)
-        boolean isSprintInProject = create.fetchExists(
+        //  SELECT *
+        //  FROM Sprints
+        //  WHERE Sprint.sprint_id = sprintID
+        //  AND Sprint.project_id = projectID;
+        SprintsRecord sprintInProject =
                 create.selectFrom(SPRINTS)
                         .where(SPRINTS.SPRINT_ID.eq(sprintID))
                         .and(SPRINTS.PROJECT_ID.eq(projectID))
-        );
+                        .fetchOneInto(SprintsRecord.class);
 
-        if (!isSprintInProject) {
+        if (sprintInProject == null) {
             throw new SprintsExceptions.SprintDoesNotExistInProject(
                     ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue());
         }
+        return sprintInProject;
     }
 
     public SprintsInProjectDto getAllSprintsForProject(int projectID) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
@@ -3,12 +3,16 @@ package org.opm.busybeaver.repository;
 import org.jooq.DSLContext;
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
+import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+import static org.opm.busybeaver.jooq.Tables.PROJECTS;
 import static org.opm.busybeaver.jooq.Tables.SPRINTS;
 
 @Repository
@@ -75,5 +79,30 @@ public class SprintsRepository {
             throw new SprintsExceptions.SprintDoesNotExistInProject(
                     ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue());
         }
+    }
+
+    public SprintsInProjectDto getAllSprintsForProject(int projectID) {
+        // SELECT Projects.project_name, Projects.project_id
+        // FROM Projects
+        // WHERE Projects.project_id = projectID;
+        SprintsInProjectDto sprintsInProjectDto = create
+                .select(PROJECTS.PROJECT_NAME, PROJECTS.PROJECT_ID)
+                .from(PROJECTS)
+                .where(PROJECTS.PROJECT_ID.eq(projectID))
+                .fetchSingleInto(SprintsInProjectDto.class);
+
+        // SELECT Sprints.sprint_id, Sprints.sprint_name, Sprints.begin_date, Sprints.end_date
+        // FROM Sprints
+        // WHERE Sprints.project_id = projectID
+        // ORDER BY Sprints.end_date ASC;
+        List<SprintSummaryDto> sprints = create
+                .select(SPRINTS.SPRINT_ID, SPRINTS.SPRINT_NAME, SPRINTS.BEGIN_DATE, SPRINTS.END_DATE)
+                .from(SPRINTS)
+                .where(SPRINTS.PROJECT_ID.eq(projectID))
+                .orderBy(SPRINTS.END_DATE.asc())
+                .fetchInto(SprintSummaryDto.class);
+
+        sprintsInProjectDto.setSprints(sprints);
+        return sprintsInProjectDto;
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -3,6 +3,7 @@ package org.opm.busybeaver.service;
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
 import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
+import org.opm.busybeaver.dto.Sprints.TasksInSprintDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
 import org.opm.busybeaver.repository.*;
@@ -61,6 +62,16 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         sprintsInProjectDto.setLocations(contextPath);
 
         return sprintsInProjectDto;
+    }
+
+    public TasksInSprintDto getAllTasksInSprint(UserDto userDto, int projectID, int sprintID, String contextPath) {
+        validateUserValidAndInsideValidProject(userDto, projectID);
+
+        sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+
+        TasksInSprintDto tasksInSprintDto = sprintsRepository.getAllTasksInSprint(projectID, sprintID);
+        tasksInSprintDto.setSprintLocation(contextPath, projectID);
+        return tasksInSprintDto;
     }
 
     @Override

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -1,15 +1,18 @@
 package org.opm.busybeaver.service;
 
-import org.opm.busybeaver.dto.Sprints.NewSprintDto;
-import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
-import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
-import org.opm.busybeaver.dto.Sprints.TasksInSprintDto;
+import org.jetbrains.annotations.NotNull;
+import org.opm.busybeaver.dto.Sprints.*;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.ErrorMessageConstants;
+import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
+import org.opm.busybeaver.jooq.tables.records.SprintsRecord;
 import org.opm.busybeaver.repository.*;
 import org.opm.busybeaver.service.ServiceInterfaces.ValidateUserAndProjectInterface;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
 
 @Service
 public final class SprintsService implements ValidateUserAndProjectInterface {
@@ -72,6 +75,95 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         TasksInSprintDto tasksInSprintDto = sprintsRepository.getAllTasksInSprint(projectID, sprintID);
         tasksInSprintDto.setSprintLocation(contextPath, projectID);
         return tasksInSprintDto;
+    }
+
+    public boolean modifySprint(UserDto userDto, int projectID, int sprintID, @NotNull EditSprintDto editSprintDto) {
+        validateUserValidAndInsideValidProject(userDto, projectID);
+
+        SprintsRecord sprintToEdit = sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+
+        modifySprintName(sprintToEdit, projectID, editSprintDto);
+        if (editSprintDto.getStartDate() != null && editSprintDto.getEndDate() != null) {
+            // Compare the new possible dates against each other
+            modifySprintStartAndEndDate(sprintToEdit, editSprintDto);
+        } else {
+            // Compare the new possible dates against their older partner dates
+            modifySprintStartDate(sprintToEdit, editSprintDto);
+            modifySprintEndDate(sprintToEdit, editSprintDto);
+        }
+
+        boolean isSprintUpdated = sprintToEdit.changed();
+        if (isSprintUpdated) {
+            sprintToEdit.update();
+        }
+
+        return isSprintUpdated;
+    }
+
+    private void modifySprintName(SprintsRecord sprintToEdit, int projectID, @NotNull EditSprintDto editSprintDto) {
+        if (editSprintDto.getSprintName() != null &&
+                !editSprintDto.getSprintName().equals(sprintToEdit.getSprintName())) {
+
+            sprintsRepository.isSprintNameInProject(projectID, editSprintDto.getSprintName());
+
+            sprintToEdit.setSprintName(editSprintDto.getSprintName());
+        }
+    }
+
+    private void modifySprintStartAndEndDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+            throws SprintsExceptions.SprintDatesInvalid {
+
+        LocalDate newStartDate = editSprintDto.getStartDate();
+        LocalDate newEndDate = editSprintDto.getEndDate();
+
+        // Just getting rid of the IDE saying potential nullability ahead...
+        if (newStartDate == null || newEndDate == null) return;
+
+        if (!newStartDate.isBefore(newEndDate)) {
+            throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+        }
+
+        if (!newStartDate.isEqual(sprintToEdit.getBeginDate())) {
+            sprintToEdit.setBeginDate(newStartDate);
+        }
+
+        if (!newEndDate.isEqual(sprintToEdit.getEndDate())) {
+            sprintToEdit.setEndDate(newEndDate);
+        }
+    }
+
+    private void modifySprintStartDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+        throws SprintsExceptions.SprintDatesInvalid {
+        if (editSprintDto.getStartDate() != null) {
+            LocalDate newStartDate = editSprintDto.getStartDate();
+            LocalDate currentEndDate = sprintToEdit.getEndDate();
+
+            if (!newStartDate.isBefore(currentEndDate)) {
+                throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+            }
+
+            if (!newStartDate.isEqual(sprintToEdit.getBeginDate())) {
+                sprintToEdit.setBeginDate(newStartDate);
+            }
+        }
+    }
+
+    private void modifySprintEndDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+        throws SprintsExceptions.SprintDatesInvalid {
+
+        if (editSprintDto.getEndDate() != null) {
+            LocalDate newStartDate = editSprintDto.getStartDate();
+            LocalDate newEndDate = editSprintDto.getEndDate();
+            LocalDate currentStartDate = sprintToEdit.getBeginDate();
+
+            if (!currentStartDate.isBefore(newEndDate)) {
+                throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+            }
+
+            if (!newEndDate.isEqual(sprintToEdit.getEndDate())) {
+                sprintToEdit.setEndDate(newEndDate);
+            }
+        }
     }
 
     @Override

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -2,6 +2,7 @@ package org.opm.busybeaver.service;
 
 import org.opm.busybeaver.dto.Sprints.NewSprintDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
+import org.opm.busybeaver.dto.Sprints.SprintsInProjectDto;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
 import org.opm.busybeaver.repository.*;
@@ -14,7 +15,6 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
     private final UsersRepository usersRepository;
     private final SprintsRepository sprintsRepository;
     private final ProjectUsersRepository projectUsersRepository;
-
     private final ProjectsRepository projectsRepository;
 
     @Autowired
@@ -52,6 +52,15 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         sprintsRepository.removeSprintFromProject(sprintID, projectID);
 
         projectsRepository.updateLastUpdatedForProject(projectID);
+    }
+
+    public SprintsInProjectDto getAllSprintsForProject(UserDto userDto, int projectID, String contextPath) {
+        validateUserValidAndInsideValidProject(userDto, projectID);
+
+        SprintsInProjectDto sprintsInProjectDto = sprintsRepository.getAllSprintsForProject(projectID);
+        sprintsInProjectDto.setLocations(contextPath);
+
+        return sprintsInProjectDto;
     }
 
     @Override

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -95,6 +95,7 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         boolean isSprintUpdated = sprintToEdit.changed();
         if (isSprintUpdated) {
             sprintToEdit.update();
+            projectsRepository.updateLastUpdatedForProject(projectID);
         }
 
         return isSprintUpdated;


### PR DESCRIPTION
**Last** (!) batch of routes, related to the sprints on a project page that a user visits:

`/api/v1/projects/{projectID}/sprints` - GET

> Allows user to retrieve all the sprints associated with a project.
> Must provide a real projectID the user is a member of.

`/api/v1/projects/{projectID}/sprints/{sprintID}` - GET

> Allows a user to retrieve all the tasks associated with a sprint, in a project.
> Must provide a real projectID the user is a member of, as well as a real sprintID contained within the project.

`/api/v1/projects/{projectID}/sprints/{sprintID}` - PUT

> Allows a user to modify a sprint within a project.
> begin_date and end_date must be sequential, and should not be the same date.
> See API Documentation (README) for more details.
> Must provide a real projectID the user is a member of, as well as a real sprintID contained within the project.

NOTE: The Project `last_updated` field will be updated accordingly only when the user modifies a sprint.

Can test locally using Postman or another API simulator. You will need to grab an authentication token after signing into the Firebase authentication service. This token will need to be placed in the Authentication: Bearer {TOKEN} header.

You can then make calls to the API locally using this setup. You may need to insert mock data into the database to get actual results.

Closes #66