### PR TITLE
Deployment on cloudflare pages

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,3 +1,6 @@
+import React, { useEffect, useState } from 'react';
+import { initializeApp } from 'firebase/app';
+import { firebaseConfig } from './firebaseConfig';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AuthProvider } from './contexts/AuthContext'; // Make sure the path matches where your AuthContext.js is located
 import './styles/App.css';
@@ -5,7 +8,21 @@ import SplashPage from './components/SplashPage';
 import UserHomePage from './components/UserHomepage';
 import UsernameSetup from './components/UsernameSetup';
 
+
 function App() {
+
+  const [isFirebaseInitialized, setIsFirebaseInitialized] = useState(false);
+
+  useEffect(() => {
+    const app = initializeApp(firebaseConfig);
+
+    setIsFirebaseInitialized(true);
+  }, []);
+
+  if (!isFirebaseInitialized) {
+    return <div>Loading...</div>;
+  }
+
   return (
     <Router>
       <div className="App">

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,7 @@ import UsernameSetup from './components/UsernameSetup';
 
 function App() {
 
+
   const [isFirebaseInitialized, setIsFirebaseInitialized] = useState(false);
 
   useEffect(() => {
@@ -20,6 +21,8 @@ function App() {
   }, []);
 
   if (!isFirebaseInitialized) {
+    // Wait until firebase is initialized before doing anything else, or
+    // the AuthContext will fail
     return <div>Loading...</div>;
   }
 

--- a/frontend/src/firebaseConfig.js
+++ b/frontend/src/firebaseConfig.js
@@ -1,7 +1,3 @@
-// Import the functions you need from the SDKs you need
-//import { initializeApp } from "firebase/app";
-// TODO: Add SDKs for Firebase products that you want to use
-// https://firebase.google.com/docs/web/setup#available-libraries
 
 // Your web app's Firebase configuration
 export const firebaseConfig = {
@@ -12,7 +8,4 @@ export const firebaseConfig = {
   messagingSenderId: process.env.REACT_APP_FIREBASE_MESSAGING_SENDER_ID,
   appId: process.env.REACT_APP_FIREBASE_APP_ID
 };
-
-// Initialize Firebase
-// const app = initializeApp(firebaseConfig);
 

--- a/frontend/src/firebaseConfig.js
+++ b/frontend/src/firebaseConfig.js
@@ -1,10 +1,10 @@
 // Import the functions you need from the SDKs you need
-import { initializeApp } from "firebase/app";
+//import { initializeApp } from "firebase/app";
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
 
 // Your web app's Firebase configuration
-const firebaseConfig = {
+export const firebaseConfig = {
   apiKey: process.env.REACT_APP_FIREBASE_API_KEY,
   authDomain: process.env.REACT_APP_FIREBASE_AUTH_DOMAIN,
   projectId: process.env.REACT_APP_FIREBASE_PROJECT_ID,
@@ -14,4 +14,5 @@ const firebaseConfig = {
 };
 
 // Initialize Firebase
-const app = initializeApp(firebaseConfig);
+// const app = initializeApp(firebaseConfig);
+


### PR DESCRIPTION
Building on cloudflare pages ran into failure because the Firebase app was not initialized before AuthContext was imported. I tried to fix this with what feels like a hack, please feel free to modify as you see fit - but currently this forces the `initializeApp` to occur before `AuthContext` starts.