### PR TITLE
RestAPI Logging

### DIFF
--- a/backend/busybeaver/build.gradle
+++ b/backend/busybeaver/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.1.4'
     id 'org.asciidoctor.jvm.convert' version '3.3.2'
     id 'nu.studer.jooq' version '9.0'
+    id 'io.freefair.lombok' version '8.6'
 }
 
 group = 'org.opm'
@@ -28,6 +29,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-jdbc'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-logging'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'org.postgresql:postgresql'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -41,6 +43,15 @@ dependencies {
     // Don't need this but removes pesky 'unknown enum constant jakarta.xml.bind.annotation.XmlAccessType.FIELD warning
     // https://github.com/jOOQ/jOOQ/issues/14865
     implementation 'jakarta.xml.bind:jakarta.xml.bind-api'
+
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'org.slf4j:slf4j-api'
+}
+
+bootJar {
+    archiveFileName = "busybeaver-api.jar"
+    enabled = true
 }
 
 // Referenced jooq plugin - https://github.com/etiennestuder/gradle-jooq-plugin

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
@@ -42,7 +42,7 @@ public final class ColumnsController implements GetUserFromBearerTokenInterface 
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
             @NotNull HttpServletResponse response
     ) {
-        NewColumnDto newColumn = columnsService.addNewColumn(userDto, newColumnDto, projectID, request.getContextPath());
+        NewColumnDto newColumn = columnsService.addNewColumn(userDto, newColumnDto, projectID, request);
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newColumn.getColumnLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
@@ -102,7 +102,7 @@ public final class ColumnsController implements GetUserFromBearerTokenInterface 
                 projectID,
                 columnID,
                 newColumnTitleDto,
-                request.getContextPath()
+                request
         );
 
         log.info("Modified column title to {}. | RID: {}", newColumnTitleDto.columnTitle(), request.getAttribute(RID));

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
@@ -3,6 +3,9 @@ package org.opm.busybeaver.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.Columns.NewColumnDto;
 import org.opm.busybeaver.dto.Columns.NewColumnIndexDto;
@@ -20,37 +23,44 @@ import org.springframework.web.bind.annotation.*;
 @ApiPrefixController
 @RestController
 @CrossOrigin
+@Slf4j
 public final class ColumnsController implements GetUserFromBearerTokenInterface {
     private final ColumnsService columnsService;
     private static final String PROJECTS_PATH = BusyBeavPaths.Constants.PROJECTS;
     private static final String COLUMNS_PATH = BusyBeavPaths.Constants.COLUMNS;
     private static final String ORDER_PATH = BusyBeavPaths.Constants.ORDER;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public ColumnsController(ColumnsService columnsService) { this.columnsService = columnsService; }
 
     @PostMapping(PROJECTS_PATH + "/{projectID}" + COLUMNS_PATH)
-    public NewColumnDto addColumnToProject(
-            HttpServletRequest request,
+    public @NotNull NewColumnDto addColumnToProject(
+            @NotNull HttpServletRequest request,
             @Valid @RequestBody NewColumnDto newColumnDto,
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
-            HttpServletResponse response
+            @NotNull HttpServletResponse response
     ) {
         NewColumnDto newColumn = columnsService.addNewColumn(userDto, newColumnDto, projectID, request.getContextPath());
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newColumn.getColumnLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
+        log.info("New column added to project. | RID: {}", request.getAttribute(RID));
+
         return newColumn;
     }
 
+    @Contract("_, _, _, _ -> new")
     @DeleteMapping(PROJECTS_PATH + "/{projectID}" + COLUMNS_PATH + "/{columnID}")
-    public SmallJsonResponse deleteColumnFromProject(
+    public @NotNull SmallJsonResponse deleteColumnFromProject(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         columnsService.deleteColumn(userDto, projectID, columnID);
+        log.info("Column removed from project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
@@ -60,41 +70,49 @@ public final class ColumnsController implements GetUserFromBearerTokenInterface 
 
     @PutMapping(PROJECTS_PATH + "/{projectID}" + COLUMNS_PATH + "/{columnID}" + ORDER_PATH)
     public NewColumnDto moveColumnInProject(
-            HttpServletRequest request,
-            @Valid @RequestBody NewColumnIndexDto newColumnIndexDto,
+            @NotNull HttpServletRequest request,
+            @Valid @RequestBody @NotNull NewColumnIndexDto newColumnIndexDto,
             @PathVariable int projectID,
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return columnsService.moveColumn(
+        NewColumnDto newColumnDto = columnsService.moveColumn(
                 userDto,
                 projectID,
                 columnID,
                 newColumnIndexDto.columnIndex(),
                 request.getContextPath()
         );
+
+        log.info("Column moved within project. | RID: {}", request.getAttribute(RID));
+
+        return newColumnDto;
     }
 
     @PutMapping(PROJECTS_PATH + "/{projectID}" + COLUMNS_PATH + "/{columnID}")
     public NewColumnDto changeColumnTitle(
-            HttpServletRequest request,
+            @NotNull HttpServletRequest request,
             @Valid @RequestBody NewColumnTitleDto newColumnTitleDto,
             @PathVariable int projectID,
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return columnsService.changeColumnTitle(
+        NewColumnDto newColumnDto = columnsService.changeColumnTitle(
                 userDto,
                 projectID,
                 columnID,
                 newColumnTitleDto,
                 request.getContextPath()
         );
+
+        log.info("Modified column title to {}. | RID: {}", newColumnTitleDto.columnTitle(), request.getAttribute(RID));
+
+        return newColumnDto;
     }
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)
     @Override
-    public UserDto getUserFromToken(HttpServletRequest request) {
+    public UserDto getUserFromToken(@NotNull HttpServletRequest request) {
         return (UserDto) request.getAttribute(BusyBeavConstants.USER_KEY_VAL.getValue());
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ColumnsController.java
@@ -59,7 +59,7 @@ public final class ColumnsController implements GetUserFromBearerTokenInterface 
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        columnsService.deleteColumn(userDto, projectID, columnID);
+        columnsService.deleteColumn(userDto, projectID, columnID, request);
         log.info("Column removed from project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
@@ -81,7 +81,7 @@ public final class ColumnsController implements GetUserFromBearerTokenInterface 
                 projectID,
                 columnID,
                 newColumnIndexDto.columnIndex(),
-                request.getContextPath()
+                request
         );
 
         log.info("Column moved within project. | RID: {}", request.getAttribute(RID));

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
@@ -63,7 +63,7 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
             @PathVariable int commentID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        commentsService.modifyCommentOnTask(userDto, projectID, taskID, commentID, newCommentBodyDto);
+        commentsService.modifyCommentOnTask(userDto, projectID, taskID, commentID, newCommentBodyDto, request);
         log.info("Comment modified. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
@@ -44,7 +44,7 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
             @NotNull HttpServletResponse response
     ) {
         CommentInTaskDto newComment = commentsService.addCommentToTask(
-                userDto, projectID, taskID, newCommentBodyDto, request.getContextPath()
+                userDto, projectID, taskID, newCommentBodyDto, request
         );
 
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newComment.getCommentLocation());
@@ -81,7 +81,7 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
             @PathVariable int commentID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        commentsService.removeCommentFromTask(userDto, projectID, taskID, commentID);
+        commentsService.removeCommentFromTask(userDto, projectID, taskID, commentID, request);
         log.info("Comment removed from task. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
@@ -3,6 +3,9 @@ package org.opm.busybeaver.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
 import org.opm.busybeaver.dto.Comments.NewCommentBodyDto;
@@ -19,24 +22,26 @@ import org.springframework.web.bind.annotation.*;
 @ApiPrefixController
 @RestController
 @CrossOrigin
+@Slf4j
 public final class CommentsController implements GetUserFromBearerTokenInterface {
 
     private final CommentsService commentsService;
     private static final String PROJECTS_PATH = BusyBeavPaths.Constants.PROJECTS;
     private static final String TASK_PATH = BusyBeavPaths.Constants.TASKS;
     private static final String COMMENT_PATH = BusyBeavPaths.Constants.COMMENTS;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public CommentsController(CommentsService commentsService) { this.commentsService = commentsService; }
 
     @PostMapping(PROJECTS_PATH + "/{projectID}" + TASK_PATH + "/{taskID}")
-    public CommentInTaskDto addCommentToTask(
-            HttpServletRequest request,
+    public @NotNull CommentInTaskDto addCommentToTask(
+            @NotNull HttpServletRequest request,
             @Valid @RequestBody NewCommentBodyDto newCommentBodyDto,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
-            HttpServletResponse response
+            @NotNull HttpServletResponse response
     ) {
         CommentInTaskDto newComment = commentsService.addCommentToTask(
                 userDto, projectID, taskID, newCommentBodyDto, request.getContextPath()
@@ -44,11 +49,14 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
 
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newComment.getCommentLocation());
         response.setStatus(HttpStatus.CREATED.value());
+        log.info("Successfully added comment to task. | RID: {}", request.getAttribute(RID));
         return newComment;
     }
 
+    @Contract("_, _, _, _, _, _ -> new")
     @PutMapping(PROJECTS_PATH +"/{projectID}" + TASK_PATH + "/{taskID}" + COMMENT_PATH + "/{commentID}")
-    public SmallJsonResponse addCommentToTask(
+    public @NotNull SmallJsonResponse addCommentToTask(
+            @NotNull HttpServletRequest request,
             @Valid @RequestBody NewCommentBodyDto newCommentBodyDto,
             @PathVariable int projectID,
             @PathVariable int taskID,
@@ -56,20 +64,25 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         commentsService.modifyCommentOnTask(userDto, projectID, taskID, commentID, newCommentBodyDto);
+        log.info("Comment modified. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
                 SuccessMessageConstants.COMMENT_MODIFIED.getValue()
         );
     }
+
+    @Contract("_, _, _, _, _ -> new")
     @DeleteMapping(PROJECTS_PATH +"/{projectID}" + TASK_PATH + "/{taskID}" + COMMENT_PATH + "/{commentID}")
-    public SmallJsonResponse removeCommentFromTask(
+    public @NotNull SmallJsonResponse removeCommentFromTask(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @PathVariable int commentID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         commentsService.removeCommentFromTask(userDto, projectID, taskID, commentID);
+        log.info("Comment removed from task. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
@@ -79,7 +92,7 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)
     @Override
-    public UserDto getUserFromToken(HttpServletRequest request) {
+    public UserDto getUserFromToken(@NotNull HttpServletRequest request) {
         return (UserDto) request.getAttribute(BusyBeavConstants.USER_KEY_VAL.getValue());
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/FirebaseAuthenticationController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/FirebaseAuthenticationController.java
@@ -25,8 +25,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
-import static org.opm.busybeaver.utils.Utils.calculateTimeLengthMillis;
-
 @Component
 @CrossOrigin
 @Slf4j
@@ -124,6 +122,10 @@ public class FirebaseAuthenticationController extends OncePerRequestFilter {
                 firebaseAuthenticationService.getEmail(),
                 firebaseAuthenticationService.getUid()
         );
+    }
+
+    private static @NotNull Long calculateTimeLengthMillis(Instant startTime) {
+        return Duration.between(startTime, Instant.now()).toMillis();
     }
 
     private static String generateReturnUniqueRequestID() {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/FirebaseAuthenticationController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/FirebaseAuthenticationController.java
@@ -5,6 +5,8 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
@@ -16,12 +18,18 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
+
+import static org.opm.busybeaver.utils.Utils.calculateTimeLengthMillis;
 
 @Component
 @CrossOrigin
+@Slf4j
 public class FirebaseAuthenticationController extends OncePerRequestFilter {
 
     private static final String BEARER = "Bearer ";
@@ -41,9 +49,18 @@ public class FirebaseAuthenticationController extends OncePerRequestFilter {
             @NotNull FilterChain filterChain
     ) throws ServletException, IOException {
 
+        final String RID = BusyBeavConstants.REQUEST_ID.getValue();
+        Instant start = Instant.now();
+
+        request.setAttribute(RID, generateReturnUniqueRequestID());
+        log.info("Starting a request. | Method: {} | URI: {} | RID: {}", request.getMethod(), request.getRequestURI(), request.getAttribute(RID));
+
         // Can skip OPTIONS requests
         if (Objects.equals(request.getMethod(), OPTIONS)) {
             filterChain.doFilter(request, response);
+            log.info("Invalid OPTIONS request. | {} ms | RID: {}",
+                    calculateTimeLengthMillis(start),
+                    request.getAttribute(RID));
             return;
         };
 
@@ -51,6 +68,9 @@ public class FirebaseAuthenticationController extends OncePerRequestFilter {
         String authorizationHeader = request.getHeader(AUTHORIZATION);
         if (authorizationHeader == null || !BEARER.equals(authorizationHeader.substring(0, BEARER.length()))) {// !authorizationHeader.contains(BEARER)) {
            sendJsonMissingAuthenticationHeader(response);
+           log.info("Missing authentication headers. | {} ms | RID: {}",
+                   calculateTimeLengthMillis(start),
+                   request.getAttribute(RID));
            return;
         }
 
@@ -59,17 +79,27 @@ public class FirebaseAuthenticationController extends OncePerRequestFilter {
 
         FirebaseAuthenticationService authentication = new FirebaseAuthenticationService(authorizationHeader);
         if (authentication.isAuthenticated()) {
+            log.info("Firebase validated the user. | {} ms | RID: {}",
+                    calculateTimeLengthMillis(start),
+                    request.getAttribute(RID));
             // Store authenticated user details for user in Controllers
             request.setAttribute(BusyBeavConstants.USER_KEY_VAL.getValue(), parseToken(authentication));
             filterChain.doFilter(request, response);
+            log.info("Request successfully finished. | {} ms | URI: {} | RID: {}",
+                    calculateTimeLengthMillis(start),
+                    request.getRequestURI(),
+                    request.getAttribute(RID));
             return;
         }
 
         sendJsonMissingAuthenticationHeader(response);
+        log.info("Firebase invalidated the user. | {} ms | RID: {}",
+                calculateTimeLengthMillis(start),
+                request.getAttribute(RID));
     }
 
 
-    private void sendJsonMissingAuthenticationHeader(HttpServletResponse response) throws IOException {
+    private void sendJsonMissingAuthenticationHeader(@NotNull HttpServletResponse response) throws IOException {
         // Handles both missing Header, and invalid Firebase Authentication
 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
@@ -88,10 +118,15 @@ public class FirebaseAuthenticationController extends OncePerRequestFilter {
         responseWriter.flush();
     }
 
-    private static UserDto parseToken(FirebaseAuthenticationService firebaseAuthenticationService) {
+    @Contract("_ -> new")
+    private static @NotNull UserDto parseToken(@NotNull FirebaseAuthenticationService firebaseAuthenticationService) {
         return new UserDto(
                 firebaseAuthenticationService.getEmail(),
                 firebaseAuthenticationService.getUid()
         );
+    }
+
+    private static String generateReturnUniqueRequestID() {
+        return UUID.randomUUID().toString();
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
@@ -40,7 +40,7 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         ProjectUserSummaryDto projectUserSummaryDto = projectUsersService
-                .getAllUsersInProject(userDto, projectID, request.getContextPath());
+                .getAllUsersInProject(userDto, projectID, request);
 
         log.info("Retrieved all users in a project. | RID: {}", request.getAttribute(RID));
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
@@ -54,7 +54,7 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
             @Valid @RequestBody UsernameDto usernameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        projectUsersService.addUserToProject(userDto, projectID, usernameDto);
+        projectUsersService.addUserToProject(userDto, projectID, usernameDto, request);
         log.info("Added a user to a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
@@ -70,7 +70,7 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
             @Valid @RequestBody UsernameDto usernameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        projectUsersService.removeUserFromProject(userDto, projectID, usernameDto);
+        projectUsersService.removeUserFromProject(userDto, projectID, usernameDto, request);
         log.info("Removed a user from a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
@@ -2,6 +2,8 @@ package org.opm.busybeaver.controller;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.ProjectUsers.ProjectUserSummaryDto;
 import org.opm.busybeaver.dto.SmallJsonResponse;
@@ -18,11 +20,13 @@ import org.springframework.web.bind.annotation.*;
 @ApiPrefixController
 @RestController
 @CrossOrigin
+@Slf4j
 public class ProjectUsersController implements GetUserFromBearerTokenInterface {
 
     private final ProjectUsersService projectUsersService;
     private static final String PROJECT_PATH = BusyBeavPaths.Constants.PROJECTS;
     private static final String USERS_PATH = BusyBeavPaths.Constants.USERS;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public ProjectUsersController(ProjectUsersService projectUsersService) {
@@ -31,20 +35,27 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
 
     @GetMapping(PROJECT_PATH + "/{projectID}" + USERS_PATH)
     public ProjectUserSummaryDto getAllUsersInProject(
-            HttpServletRequest request,
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return projectUsersService.getAllUsersInProject(userDto, projectID, request.getContextPath());
+        ProjectUserSummaryDto projectUserSummaryDto = projectUsersService
+                .getAllUsersInProject(userDto, projectID, request.getContextPath());
+
+        log.info("Retrieved all users in a project. | RID: {}", request.getAttribute(RID));
+
+        return projectUserSummaryDto;
     }
 
     @PostMapping(PROJECT_PATH + "/{projectID}" + USERS_PATH)
     public SmallJsonResponse addUserToProject(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @Valid @RequestBody UsernameDto usernameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         projectUsersService.addUserToProject(userDto, projectID, usernameDto);
+        log.info("Added a user to a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
@@ -54,11 +65,13 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
 
     @DeleteMapping(PROJECT_PATH + "/{projectID}" + USERS_PATH)
     public SmallJsonResponse removeUserFromProject(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @Valid @RequestBody UsernameDto usernameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         projectUsersService.removeUserFromProject(userDto, projectID, usernameDto);
+        log.info("Removed a user from a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
@@ -68,7 +81,7 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)
     @Override
-    public UserDto getUserFromToken(HttpServletRequest request) {
+    public UserDto getUserFromToken(@NotNull HttpServletRequest request) {
         return (UserDto) request.getAttribute(BusyBeavConstants.USER_KEY_VAL.getValue());
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
@@ -60,7 +60,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        projectsService.deleteProject(userDto, projectID);
+        projectsService.deleteProject(userDto, projectID, request);
         log.info("Deleted a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
@@ -42,7 +42,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
             @NotNull HttpServletResponse response
     ) {
-        NewProjectDto projectDto = projectsService.makeNewProject(userDto, newProjectDto, request.getContextPath());
+        NewProjectDto projectDto = projectsService.makeNewProject(userDto, newProjectDto, request);
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), projectDto.getProjectLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
@@ -74,7 +74,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @NotNull HttpServletRequest request,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        ProjectsSummariesDto projectsSummariesDto = projectsService.getUserProjectsSummary(userDto, request.getContextPath());
+        ProjectsSummariesDto projectsSummariesDto = projectsService.getUserProjectsSummary(userDto, request);
         log.info("Retrieved user's project summaries. | RID {}", request.getAttribute(RID));
 
         return projectsSummariesDto;
@@ -86,7 +86,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        ProjectDetailsDto projectDetailsDto = projectsService.getSpecificProjectDetails(userDto, projectID, request.getContextPath());
+        ProjectDetailsDto projectDetailsDto = projectsService.getSpecificProjectDetails(userDto, projectID, request);
         log.info("Retrieved project details. | RID: {}", request.getAttribute(RID));
 
         return projectDetailsDto;
@@ -100,7 +100,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
             @Valid @RequestBody NewProjectNameDto newProjectNameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        projectsService.modifyProjectName(userDto, projectID, newProjectNameDto);
+        projectsService.modifyProjectName(userDto, projectID, newProjectNameDto, request);
         log.info("Modified a project name. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectsController.java
@@ -3,6 +3,9 @@ package org.opm.busybeaver.controller;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.Projects.NewProjectDto;
 import org.opm.busybeaver.dto.Projects.NewProjectNameDto;
@@ -22,35 +25,43 @@ import org.springframework.web.bind.annotation.*;
 @ApiPrefixController
 @RestController
 @CrossOrigin
+@Slf4j
 public final class ProjectsController implements GetUserFromBearerTokenInterface {
 
     private final ProjectsService projectsService;
     private static final String PROJECTS_PATH = BusyBeavPaths.Constants.PROJECTS;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public ProjectsController(ProjectsService projectsService) { this.projectsService = projectsService; }
 
     @PostMapping(PROJECTS_PATH)
-    public NewProjectDto makeNewProject(
-            HttpServletRequest request,
+    public @NotNull NewProjectDto makeNewProject(
+            @NotNull HttpServletRequest request,
             @Valid @RequestBody NewProjectDto newProjectDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
-            HttpServletResponse response
+            @NotNull HttpServletResponse response
     ) {
         NewProjectDto projectDto = projectsService.makeNewProject(userDto, newProjectDto, request.getContextPath());
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), projectDto.getProjectLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
+        log.info("Created a new project called {}. | RID: {}",
+                newProjectDto.getProjectName(),
+                request.getAttribute(RID));
+
         return projectDto;
     }
 
+    @Contract("_, _, _ -> new")
     @DeleteMapping(PROJECTS_PATH + "/{projectID}")
-    public SmallJsonResponse deleteProject(
-            HttpServletRequest request,
+    public @NotNull SmallJsonResponse deleteProject(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         projectsService.deleteProject(userDto, projectID);
+        log.info("Deleted a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
@@ -59,29 +70,39 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
     }
 
     @GetMapping(PROJECTS_PATH)
-    public ProjectsSummariesDto getUserProjectsSummary(
-            HttpServletRequest request,
+    public @NotNull ProjectsSummariesDto getUserProjectsSummary(
+            @NotNull HttpServletRequest request,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return projectsService.getUserProjectsSummary(userDto, request.getContextPath());
+        ProjectsSummariesDto projectsSummariesDto = projectsService.getUserProjectsSummary(userDto, request.getContextPath());
+        log.info("Retrieved user's project summaries. | RID {}", request.getAttribute(RID));
+
+        return projectsSummariesDto;
     }
 
     @GetMapping(PROJECTS_PATH + "/{projectID}")
-    public ProjectDetailsDto getSpecificProjectDetails(
-            HttpServletRequest request,
+    public @NotNull ProjectDetailsDto getSpecificProjectDetails(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return projectsService.getSpecificProjectDetails(userDto, projectID, request.getContextPath());
+        ProjectDetailsDto projectDetailsDto = projectsService.getSpecificProjectDetails(userDto, projectID, request.getContextPath());
+        log.info("Retrieved project details. | RID: {}", request.getAttribute(RID));
+
+        return projectDetailsDto;
     }
 
+    @Contract("_, _, _, _ -> new")
     @PutMapping(PROJECTS_PATH +"/{projectID}")
-    public SmallJsonResponse modifyProjectName(
+    public @NotNull SmallJsonResponse modifyProjectName(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @Valid @RequestBody NewProjectNameDto newProjectNameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         projectsService.modifyProjectName(userDto, projectID, newProjectNameDto);
+        log.info("Modified a project name. | RID: {}", request.getAttribute(RID));
+
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
                 SuccessMessageConstants.PROJECT_NAME_MODIFIED.getValue()
@@ -90,7 +111,7 @@ public final class ProjectsController implements GetUserFromBearerTokenInterface
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)
     @Override
-    public UserDto getUserFromToken(HttpServletRequest request) {
+    public UserDto getUserFromToken(@NotNull HttpServletRequest request) {
         return (UserDto) request.getAttribute(BusyBeavConstants.USER_KEY_VAL.getValue());
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
@@ -41,7 +41,7 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @NotNull HttpServletResponse response
     ) {
 
-        SprintSummaryDto newSprint = sprintsService.addSprint(userDto, projectID, newSprintDto, request.getContextPath());
+        SprintSummaryDto newSprint = sprintsService.addSprint(userDto, projectID, newSprintDto, request);
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newSprint.getSprintLocation());
         response.setStatus(HttpStatus.CREATED.value());
         log.info("Added sprint '{}' to a project. | RID: {}", newSprintDto.getSprintName(), request.getAttribute(RID));
@@ -57,7 +57,7 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @PathVariable int sprintID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        sprintsService.removeSprintFromProject(userDto, projectID, sprintID);
+        sprintsService.removeSprintFromProject(userDto, projectID, sprintID, request);
         log.info("Removed sprint from a project. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
@@ -73,7 +73,7 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         SprintsInProjectDto sprintsInProjectDto = sprintsService
-                .getAllSprintsForProject(userDto, projectID, request.getContextPath());
+                .getAllSprintsForProject(userDto, projectID, request);
 
         log.info("Retrieved all sprints for a project. | RID: {}", request.getAttribute(RID));
 
@@ -88,7 +88,7 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         TasksInSprintDto tasksInSprintDto = sprintsService
-                .getAllTasksInSprint(userDto, projectID, sprintID, request.getContextPath());
+                .getAllTasksInSprint(userDto, projectID, sprintID, request);
 
         log.info("Retrieved all tasks for a sprint in a project. | RID: {}", request.getAttribute(RID));
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/SprintsController.java
@@ -104,7 +104,7 @@ public final class SprintsController implements GetUserFromBearerTokenInterface 
             @Valid @RequestBody EditSprintDto editSprintDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        boolean sprintModified = sprintsService.modifySprint(userDto, projectID, sprintID, editSprintDto);
+        boolean sprintModified = sprintsService.modifySprint(userDto, projectID, sprintID, editSprintDto, request);
         if (sprintModified) {
             log.info("Sprint successfully modified. | RID: {}", request.getAttribute(RID));
             return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
@@ -4,6 +4,9 @@ import com.google.api.Http;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.Contract;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Tasks.EditTaskDto;
@@ -24,54 +27,68 @@ import java.util.Map;
 @ApiPrefixController
 @RestController
 @CrossOrigin
+@Slf4j
 public final class TasksController implements GetUserFromBearerTokenInterface {
     private final TasksService tasksService;
     private static final String PROJECTS_PATH = BusyBeavPaths.Constants.PROJECTS;
     private static final String TASKS_PATH  = BusyBeavPaths.Constants.TASKS;
     private static final String COLUMNS_PATH  = BusyBeavPaths.Constants.COLUMNS;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public TasksController (TasksService tasksService) { this.tasksService = tasksService; }
 
     @GetMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")
     public TaskDetailsDto getTaskDetails(
-            HttpServletRequest request,
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        return tasksService.getTaskDetails(userDto, projectID, taskID, request.getContextPath());
+        TaskDetailsDto taskDetailsDto = tasksService
+                .getTaskDetails(userDto, projectID, taskID, request.getContextPath());
+
+        log.info("Retrieved all details for task {}. | RID: {}", taskID, request.getAttribute(RID));
+
+        return taskDetailsDto;
     }
 
     @PostMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH)
-    public TaskCreatedDto addTask(
-            HttpServletRequest request,
+    public @NotNull TaskCreatedDto addTask(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @Valid @RequestBody NewTaskDtoExtended newTaskDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
-            HttpServletResponse response
+            @NotNull HttpServletResponse response
     ) {
         TaskCreatedDto taskCreatedDto = tasksService.addTask(newTaskDto, userDto, projectID, request.getContextPath());
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), taskCreatedDto.getTaskLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
+        log.info("Made a new task called '{}'. | RID: {}", newTaskDto.getTitle(), request.getAttribute(RID));
+
         return taskCreatedDto;
     }
 
+    @Contract("_, _, _, _, _ -> new")
     @PutMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}" + COLUMNS_PATH + "/{columnID}")
-    public SmallJsonResponse moveTask(
+    public @NotNull SmallJsonResponse moveTask(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         tasksService.moveTask(userDto, projectID, taskID, columnID);
+        log.info("Moved task to a new column. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(HttpStatus.OK.value(), SuccessMessageConstants.TASK_MOVED.getValue());
     }
 
+    @Contract("_, _, _, _, _ -> new")
     @PutMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")
-    public SmallJsonResponse modifyTask(
+    public @NotNull SmallJsonResponse modifyTask(
+            HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @Valid @RequestBody Map<String, Object> editTaskData,
@@ -79,25 +96,30 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
     ) {
         // Including the
         if (tasksService.modifyTask(userDto, projectID, taskID, editTaskData)) {
+           log.info("Task successfully modified. | RID: {}", request.getAttribute(RID));
            return new SmallJsonResponse(
                    HttpStatus.OK.value(),
                    SuccessMessageConstants.TASK_MODIFIED.getValue()
            );
         }
 
+        log.info("Task was not modified, no changes found. | RID: {}", request.getAttribute(RID));
         return new SmallJsonResponse(
                 HttpStatus.OK.value(),
                 SuccessMessageConstants.TASK_NOT_MODIFIED.getValue()
         );
     }
 
+    @Contract("_, _, _, _ -> new")
     @DeleteMapping(PROJECTS_PATH + "/{projectID}" + TASKS_PATH + "/{taskID}")
-    public SmallJsonResponse deleteTask(
+    public @NotNull SmallJsonResponse deleteTask(
+            @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @PathVariable int taskID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         tasksService.deleteTask(userDto, projectID, taskID);
+        log.info("Task was successfully deleted. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(HttpStatus.OK.value(), SuccessMessageConstants.TASK_DELETED.getValue());
     }
@@ -105,7 +127,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
 
     @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL)
     @Override
-    public UserDto getUserFromToken(HttpServletRequest request) {
+    public UserDto getUserFromToken(@NotNull HttpServletRequest request) {
         return (UserDto) request.getAttribute(BusyBeavConstants.USER_KEY_VAL.getValue());
     }
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
@@ -95,7 +95,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         // Including the
-        if (tasksService.modifyTask(userDto, projectID, taskID, editTaskData)) {
+        if (tasksService.modifyTask(userDto, projectID, taskID, editTaskData, request)) {
            log.info("Task successfully modified. | RID: {}", request.getAttribute(RID));
            return new SmallJsonResponse(
                    HttpStatus.OK.value(),

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TasksController.java
@@ -1,6 +1,5 @@
 package org.opm.busybeaver.controller;
 
-import com.google.api.Http;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -9,7 +8,6 @@ import org.jetbrains.annotations.Contract;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
 import org.opm.busybeaver.dto.SmallJsonResponse;
-import org.opm.busybeaver.dto.Tasks.EditTaskDto;
 import org.opm.busybeaver.dto.Tasks.NewTaskDtoExtended;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
 import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
@@ -46,7 +44,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
         TaskDetailsDto taskDetailsDto = tasksService
-                .getTaskDetails(userDto, projectID, taskID, request.getContextPath());
+                .getTaskDetails(userDto, projectID, taskID, request);
 
         log.info("Retrieved all details for task {}. | RID: {}", taskID, request.getAttribute(RID));
 
@@ -61,7 +59,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
             @NotNull HttpServletResponse response
     ) {
-        TaskCreatedDto taskCreatedDto = tasksService.addTask(newTaskDto, userDto, projectID, request.getContextPath());
+        TaskCreatedDto taskCreatedDto = tasksService.addTask(newTaskDto, userDto, projectID, request);
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), taskCreatedDto.getTaskLocation());
         response.setStatus(HttpStatus.CREATED.value());
 
@@ -79,7 +77,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
             @PathVariable int columnID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        tasksService.moveTask(userDto, projectID, taskID, columnID);
+        tasksService.moveTask(userDto, projectID, taskID, columnID, request);
         log.info("Moved task to a new column. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(HttpStatus.OK.value(), SuccessMessageConstants.TASK_MOVED.getValue());
@@ -118,7 +116,7 @@ public final class TasksController implements GetUserFromBearerTokenInterface {
             @PathVariable int taskID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        tasksService.deleteTask(userDto, projectID, taskID);
+        tasksService.deleteTask(userDto, projectID, taskID, request);
         log.info("Task was successfully deleted. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(HttpStatus.OK.value(), SuccessMessageConstants.TASK_DELETED.getValue());

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TeamsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TeamsController.java
@@ -41,7 +41,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @NotNull HttpServletRequest request,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        TeamsSummariesDto teamsSummariesDto = teamsService.getUserHomePageTeams(userDto, request.getContextPath());
+        TeamsSummariesDto teamsSummariesDto = teamsService.getUserHomePageTeams(userDto, request);
         log.info("Retrieved user's team summaries. | RID: {}", request.getAttribute(RID));
 
         return teamsSummariesDto;
@@ -54,7 +54,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
             @NotNull HttpServletResponse response
     ) {
-        NewTeamDto newTeam = teamsService.makeNewTeam(userDto, newTeamOnlyTeamNameDto, request.getContextPath());
+        NewTeamDto newTeam = teamsService.makeNewTeam(userDto, newTeamOnlyTeamNameDto, request);
         response.setHeader(BusyBeavConstants.LOCATION.getValue(), newTeam.getTeamLocation());
         response.setStatus(HttpStatus.CREATED.value());
         log.info("Created a new team with team name '{}'. | RID: {}",
@@ -86,7 +86,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @PathVariable int teamID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        ProjectsByTeamDto projectsByTeamDto = teamsService.getProjectsAssociatedWithTeam(userDto, teamID, request.getContextPath());
+        ProjectsByTeamDto projectsByTeamDto = teamsService.getProjectsAssociatedWithTeam(userDto, teamID, request);
         log.info("Successfully retrieved all projects for a team. | RID: {}", request.getAttribute(RID));
 
         return projectsByTeamDto;
@@ -98,7 +98,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @PathVariable int teamID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        MembersInTeamDto membersInTeamDto = teamsService.getMembersInTeam(userDto, teamID, request.getContextPath());
+        MembersInTeamDto membersInTeamDto = teamsService.getMembersInTeam(userDto, teamID, request);
         log.info("Successfully retrieved all members for a team. | RID: {}", request.getAttribute(RID));
 
         return membersInTeamDto;
@@ -113,7 +113,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto,
             @NotNull HttpServletResponse response
     ) {
-        String newUserInTeamLocation = teamsService.addMemberToTeam(userDto, teamID, usernameToAdd, request.getContextPath());
+        String newUserInTeamLocation = teamsService.addMemberToTeam(userDto, teamID, usernameToAdd, request);
         response.setHeader(
                 BusyBeavConstants.LOCATION.getValue(),
                 newUserInTeamLocation

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TeamsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/TeamsController.java
@@ -71,7 +71,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @PathVariable int teamID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        teamsService.deleteTeam(userDto, teamID);
+        teamsService.deleteTeam(userDto, teamID, request);
         log.info("Deleted a team. | RID: {}", request.getAttribute(RID));
 
         return new SmallJsonResponse(
@@ -135,7 +135,7 @@ public final class TeamsController implements GetUserFromBearerTokenInterface {
             @PathVariable int teamID,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-       teamsService.removeMemberFromTeam(userDto, userID, teamID);
+       teamsService.removeMemberFromTeam(userDto, userID, teamID, request);
 
        log.info("Removed a member from a team. | RID: {}", request.getAttribute(RID));
        return new SmallJsonResponse(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/UsersController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/UsersController.java
@@ -44,7 +44,7 @@ public final class UsersController implements GetUserFromBearerTokenInterface {
     ) throws UsersExceptions.UserAlreadyExistsException {
 
         userDto.setUsername(usernameRegisterDto.username());
-        AuthenticatedUser newUser = usersService.registerUser(userDto);
+        AuthenticatedUser newUser = usersService.registerUser(userDto, request);
         response.setStatus(HttpStatus.CREATED.value());
         log.info("Added a new user. | RID: {}", request.getAttribute(RID));
 
@@ -56,7 +56,7 @@ public final class UsersController implements GetUserFromBearerTokenInterface {
             @NotNull HttpServletRequest request,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto)
     throws UsersExceptions.UserDoesNotExistException {
-        AuthenticatedUser authenticatedUser = usersService.getUserByEmailAndId(userDto);
+        AuthenticatedUser authenticatedUser = usersService.getUserByEmailAndId(userDto, request);
         log.info("Authenticated user. | RID: {}", request.getAttribute(RID));
 
         return authenticatedUser;

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/BusyBeavConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/BusyBeavConstants.java
@@ -5,7 +5,8 @@ public enum BusyBeavConstants {
     JSON_CONTENT_TYPE("application/json"),
     UTF_8_ENCODING("UTF-8"),
     LOCATION("Location"),
-    RESOURCES_DIR("./src/main/resources/");
+    RESOURCES_DIR("./src/main/resources/"),
+    REQUEST_ID("RID");
 
     private final String value;
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 import org.jooq.exception.NoDataFoundException;
 import org.opm.busybeaver.dto.Columns.NewColumnDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.DefaultColumnNames;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Columns.ColumnsExceptions;
@@ -23,6 +24,7 @@ import static org.opm.busybeaver.jooq.Tables.COLUMNS;
 @Component
 public class ColumnsRepository {
     private final DSLContext create;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public ColumnsRepository(DSLContext dslContext) { this.create = dslContext; }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/UsersRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/UsersRepository.java
@@ -1,7 +1,11 @@
 package org.opm.busybeaver.repository;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.jooq.DSLContext;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Users.UsersExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
@@ -9,21 +13,25 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
+import org.springframework.stereotype.Service;
 
 import static org.opm.busybeaver.jooq.tables.Beaverusers.BEAVERUSERS;
 
 @Repository
 @Component
+@Slf4j
 public class UsersRepository {
 
     private final DSLContext create;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public UsersRepository(DSLContext dslContext) {
         this.create = dslContext;
     }
 
-    public BeaverusersRecord getUserByEmailAndId(UserDto userDto) throws UsersExceptions.UserDoesNotExistException {
+    public BeaverusersRecord getUserByEmailAndId(@NotNull UserDto userDto, HttpServletRequest request)
+            throws UsersExceptions.UserDoesNotExistException {
         BeaverusersRecord beaverUser = create
                 .selectFrom(BEAVERUSERS)
                 .where(BEAVERUSERS.EMAIL.eq(userDto.getEmail()))
@@ -31,26 +39,46 @@ public class UsersRepository {
                 .fetchOne();
 
         if (beaverUser == null) {
-            throw new UsersExceptions.UserDoesNotExistException(ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue());
+            UsersExceptions.UserDoesNotExistException userDoesNotExistException =
+                    new UsersExceptions.UserDoesNotExistException(ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    userDoesNotExistException);
+
+            throw userDoesNotExistException;
         }
 
         return beaverUser;
     }
 
-    public BeaverusersRecord getUserByUsername(String username) throws UsersExceptions.UserDoesNotExistException {
+    public BeaverusersRecord getUserByUsername(String username, HttpServletRequest request)
+            throws UsersExceptions.UserDoesNotExistException {
         BeaverusersRecord beaverUser = create
                 .selectFrom(BEAVERUSERS)
                 .where(BEAVERUSERS.USERNAME.eq(username))
                 .fetchOne();
 
         if (beaverUser == null) {
-            throw new UsersExceptions.UserDoesNotExistException(ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue());
+            UsersExceptions.UserDoesNotExistException userDoesNotExistException =
+                    new UsersExceptions.UserDoesNotExistException(ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.USER_DOES_NOT_EXIST.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    userDoesNotExistException);
+
+            throw userDoesNotExistException;
         }
 
         return beaverUser;
     }
 
-    public String registerUser(UserDto userDto) throws UsersExceptions.UserAlreadyExistsException {
+    public String registerUser(@NotNull UserDto userDto, HttpServletRequest request)
+            throws UsersExceptions.UserAlreadyExistsException {
         try {
             return create.insertInto(BEAVERUSERS, BEAVERUSERS.EMAIL, BEAVERUSERS.FIREBASE_ID, BEAVERUSERS.USERNAME)
                     .values(userDto.getEmail(), userDto.getFirebase_id(), userDto.getUsername())
@@ -59,7 +87,16 @@ public class UsersRepository {
 
         } catch(DuplicateKeyException e) {
             // User with those details already exists
-            throw new UsersExceptions.UserAlreadyExistsException(ErrorMessageConstants.USER_ALREADY_EXISTS.getValue());
+            UsersExceptions.UserAlreadyExistsException userAlreadyExistsException =
+                    new UsersExceptions.UserAlreadyExistsException(ErrorMessageConstants.USER_ALREADY_EXISTS.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.USER_ALREADY_EXISTS.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    userAlreadyExistsException);
+
+            throw userAlreadyExistsException;
         }
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ColumnsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ColumnsService.java
@@ -1,8 +1,12 @@
 package org.opm.busybeaver.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Columns.NewColumnDto;
 import org.opm.busybeaver.dto.Columns.NewColumnTitleDto;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Columns.ColumnsExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
@@ -13,12 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class ColumnsService implements ValidateUserAndProjectInterface {
     private final ProjectsRepository projectsRepository;
     private final UsersRepository usersRepository;
     private final ColumnsRepository columnsRepository;
     private final TasksRepository tasksRepository;
     private final ProjectUsersRepository projectUsersRepository;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public ColumnsService(
@@ -49,7 +55,7 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
         return newColumn;
     }
 
-    public void deleteColumn(UserDto userDto, int projectID, int columnID) {
+    public void deleteColumn(UserDto userDto, int projectID, int columnID, HttpServletRequest request) {
         // Validate user, is user in project
         validateUserValidAndInsideValidProject(userDto, projectID);
 
@@ -58,7 +64,17 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
 
         // Validate column no longer contains any tasks
         if (tasksRepository.doesColumnContainTasks(projectID, columnID)) {
-            throw new ColumnsExceptions.ColumnStillContainsTasks(ErrorMessageConstants.COLUMN_CONTAINS_TASKS.getValue());
+            ColumnsExceptions.ColumnStillContainsTasks columnStillContainsTasks =
+                    new ColumnsExceptions.ColumnStillContainsTasks(
+                            ErrorMessageConstants.COLUMN_CONTAINS_TASKS.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.COLUMN_CONTAINS_TASKS.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    columnStillContainsTasks);
+
+            throw columnStillContainsTasks;
         }
 
         // Remove column, shift column indexes of other columns
@@ -68,7 +84,11 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
-    public NewColumnDto moveColumn(UserDto userDto, int projectID, int columnID, int newColumnIndex, String contextPath)
+    public NewColumnDto moveColumn(UserDto userDto,
+                                   int projectID,
+                                   int columnID,
+                                   int newColumnIndex,
+                                   HttpServletRequest request)
         throws ColumnsExceptions.ColumnIndexIdentical,
             ColumnsExceptions.ColumnIndexOutOfBounds {
         // Validate user, is user in project
@@ -80,7 +100,17 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
 
         // Validate new index is different from previous
         if (currentIndex == newColumnIndex) {
-            throw new ColumnsExceptions.ColumnIndexIdentical(ErrorMessageConstants.COLUMN_POSITION_THE_SAME.getValue());
+            ColumnsExceptions.ColumnIndexIdentical columnIndexIdentical =
+                    new ColumnsExceptions.ColumnIndexIdentical(
+                            ErrorMessageConstants.COLUMN_POSITION_THE_SAME.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.COLUMN_POSITION_THE_SAME.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    columnIndexIdentical);
+
+            throw columnIndexIdentical;
         }
 
         // Validate index is within valid range of columns in project, zero-based indexing
@@ -88,25 +118,35 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
         int maxIndex = columnsInProject - 1;
 
         if (newColumnIndex > maxIndex || newColumnIndex < 0) {
-            throw new ColumnsExceptions.ColumnIndexOutOfBounds(
-                    ErrorMessageConstants.COLUMN_INDEX_OUT_OF_BOUNDS.getValue());
+            ColumnsExceptions.ColumnIndexOutOfBounds columnIndexOutOfBounds =
+                    new ColumnsExceptions.ColumnIndexOutOfBounds(
+                            ErrorMessageConstants.COLUMN_INDEX_OUT_OF_BOUNDS.getValue());
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.COLUMN_INDEX_OUT_OF_BOUNDS.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    columnIndexOutOfBounds);
+
+            throw columnIndexOutOfBounds;
         }
 
         // If new index is less than current index, then find all columns from new up to current - 1, and increment
         if (newColumnIndex < currentIndex) {
             // For example going from 3 (currentIndex) to 1 (newIndex), shift 1 and 2 up to 2 and 3
             columnsRepository.incrementColumnIndexes(projectID, newColumnIndex, currentIndex - 1);
+            log.info("Moved columns beneath this column, forward. | RID: {}", request.getAttribute(RID));
         }
 
         // If new index is greater than current index, find all columns from current + 1 to new and decrement
         if (newColumnIndex > currentIndex) {
             // For example going from 1 (currentIndex) to 3 (newIndex), shift 2 and 3 down to 1 and 2
             columnsRepository.decrementColumnIndexes(projectID, currentIndex + 1, newColumnIndex);
+            log.info("Moved columns above this column, backward. | RID: {}", request.getAttribute(RID));
         }
 
         // Update column index
         NewColumnDto movedColumn = columnsRepository.changeColumnIndexAndReturn(projectID, columnID, newColumnIndex);
-        movedColumn.setColumnLocation(contextPath, projectID);
+        movedColumn.setColumnLocation(request.getContextPath(), projectID);
         return movedColumn;
     }
 
@@ -114,7 +154,7 @@ public class ColumnsService implements ValidateUserAndProjectInterface {
             UserDto userDto,
             int projectID,
             int columnID,
-            NewColumnTitleDto newColumnTitleDto,
+            @NotNull NewColumnTitleDto newColumnTitleDto,
             String contextPath) throws ColumnsExceptions.ColumnTitleIdentical {
 
         // Validate user, is user in project

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/CommentsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/CommentsService.java
@@ -1,8 +1,12 @@
 package org.opm.busybeaver.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
 import org.opm.busybeaver.dto.Comments.NewCommentBodyDto;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Comments.CommentsExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
@@ -13,12 +17,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 public class CommentsService implements ValidateUserAndProjectInterface {
     private final UsersRepository usersRepository;
     private final CommentsRepository commentsRepository;
     private final TasksRepository tasksRepository;
     private final ProjectUsersRepository projectUsersRepository;
     private final ProjectsRepository projectsRepository;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public CommentsService(
@@ -52,7 +58,8 @@ public class CommentsService implements ValidateUserAndProjectInterface {
             int projectID,
             int taskID,
             int commentID,
-            NewCommentBodyDto newCommentBodyDto) throws CommentsExceptions.CommentBodyIdenticalNotModified {
+            @NotNull NewCommentBodyDto newCommentBodyDto,
+            HttpServletRequest request) throws CommentsExceptions.CommentBodyIdenticalNotModified {
         BeaverusersRecord commenter = validateUserValidAndInsideValidProject(userDto, projectID);
 
         tasksRepository.doesTaskExistInProject(taskID, projectID);
@@ -62,8 +69,17 @@ public class CommentsService implements ValidateUserAndProjectInterface {
 
         // Check if comment bodies are identical
         if (comment.getCommentBody().equals(newCommentBodyDto.commentBody())) {
-            throw new CommentsExceptions.CommentBodyIdenticalNotModified(
-                    ErrorMessageConstants.COMMENT_EQUIVALENT_NOT_MODIFIED.getValue());
+            CommentsExceptions.CommentBodyIdenticalNotModified commentBodyIdenticalNotModified =
+                    new CommentsExceptions.CommentBodyIdenticalNotModified(
+                            ErrorMessageConstants.COMMENT_EQUIVALENT_NOT_MODIFIED.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.COMMENT_EQUIVALENT_NOT_MODIFIED.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    commentBodyIdenticalNotModified);
+
+            throw commentBodyIdenticalNotModified;
         }
 
         commentsRepository.modifyCommentOnTask(taskID, commentID, newCommentBodyDto);

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/FirebaseAuthenticationService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/FirebaseAuthenticationService.java
@@ -4,8 +4,7 @@ import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseAuthException;
 import com.google.firebase.auth.FirebaseToken;
 
-
-public class FirebaseAuthenticationService  {
+public final class FirebaseAuthenticationService  {
     private String email = null;
     private String uid = null;
     private boolean isAuthenticated = false;

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectUsersService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectUsersService.java
@@ -36,11 +36,11 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
         this.usersRepository = usersRepository;
     }
 
-    public @NotNull ProjectUserSummaryDto getAllUsersInProject(UserDto userDto, int projectID, String contextPath) {
-       validateUserValidAndInsideValidProject(userDto, projectID);
+    public @NotNull ProjectUserSummaryDto getAllUsersInProject(UserDto userDto, int projectID, HttpServletRequest request) {
+       validateUserValidAndInsideValidProject(userDto, projectID, request);
 
        ProjectUserSummaryDto projectUserSummaryDto = projectUsersRepository.getAllUsersInProject(projectID);
-       projectUserSummaryDto.setLocations(contextPath);
+       projectUserSummaryDto.setLocations(request.getContextPath());
 
        return projectUserSummaryDto;
     }
@@ -53,13 +53,13 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
         throws ProjectUsersExceptions.UserAlreadyInProject
     {
         // Validate user exists, validate user in project
-        validateUserValidAndInsideValidProject(userDto, projectID);
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
         // Validate user to add exists
-        BeaverusersRecord userToAdd = usersRepository.getUserByUsername(usernameDto.username());
+        BeaverusersRecord userToAdd = usersRepository.getUserByUsername(usernameDto.username(), request);
 
         // Verify user is not in project
-        if (projectUsersRepository.isUserInProjectAndDoesProjectExist(userToAdd.getUserId(), projectID)) {
+        if (projectUsersRepository.isUserInProjectAndDoesProjectExist(userToAdd.getUserId(), projectID, request)) {
             ProjectUsersExceptions.UserAlreadyInProject userAlreadyInProject =
                     new ProjectUsersExceptions.UserAlreadyInProject(
                             ErrorMessageConstants.USER_ALREADY_IN_PROJECT.getValue());
@@ -87,14 +87,14 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
             HttpServletRequest request)
         throws ProjectUsersExceptions.ProjectCannotHaveZeroUsers {
         // Validate user exists, validate user in project
-        validateUserValidAndInsideValidProject(userDto, projectID);
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
         // Validate user to remove exists
-        BeaverusersRecord userToRemove = usersRepository.getUserByUsername(usernameDto.username());
+        BeaverusersRecord userToRemove = usersRepository.getUserByUsername(usernameDto.username(), request);
 
         // Verify user to remove exists in Project, skip if removing user wants to remove themselves as already verified
         if (!userDto.getEmail().equals(userToRemove.getEmail())) {
-            projectUsersRepository.isUserInProjectAndDoesProjectExist(userToRemove.getUserId(), projectID);
+            projectUsersRepository.isUserInProjectAndDoesProjectExist(userToRemove.getUserId(), projectID, request);
         }
 
         // Ensure not the last user in the project
@@ -120,11 +120,14 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
     }
 
     @Override
-    public @NotNull BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID) {
-        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto);
+    public @NotNull BeaverusersRecord validateUserValidAndInsideValidProject(
+            UserDto userDto,
+            int projectID,
+            HttpServletRequest request) {
+        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto, request);
 
         // Validate user in project and project exists
-        projectUsersRepository.isUserInProjectAndDoesProjectExist(beaverusersRecord.getUserId(), projectID);
+        projectUsersRepository.isUserInProjectAndDoesProjectExist(beaverusersRecord.getUserId(), projectID, request);
 
         return beaverusersRecord;
     }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ServiceInterfaces/ValidateUserAndProjectInterface.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ServiceInterfaces/ValidateUserAndProjectInterface.java
@@ -1,9 +1,10 @@
 package org.opm.busybeaver.service.ServiceInterfaces;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.exceptions.Projects.ProjectsExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
 
 public interface ValidateUserAndProjectInterface {
-    BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID);
+    BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID, HttpServletRequest request);
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -39,46 +39,50 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         this.projectsRepository = projectsRepository;
     }
 
-    public @NotNull SprintSummaryDto addSprint(UserDto userDto, int projectID, @NotNull NewSprintDto newSprintDto, String contextPath) {
-        validateUserValidAndInsideValidProject(userDto, projectID);
+    public @NotNull SprintSummaryDto addSprint(
+            UserDto userDto,
+            int projectID,
+            @NotNull NewSprintDto newSprintDto,
+            HttpServletRequest request) {
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
-        sprintsRepository.isSprintNameInProject(projectID, newSprintDto.sprintName());
+        sprintsRepository.isSprintNameInProject(projectID, newSprintDto.sprintName(), request);
 
         SprintSummaryDto newSprint = sprintsRepository.addSprintToProject(projectID, newSprintDto);
 
-        newSprint.setSprintLocation(contextPath, projectID);
+        newSprint.setSprintLocation(request.getContextPath(), projectID);
 
         projectsRepository.updateLastUpdatedForProject(projectID);
 
         return newSprint;
     }
 
-    public void removeSprintFromProject(UserDto userDto, int projectID, int sprintID) {
-        validateUserValidAndInsideValidProject(userDto, projectID);
+    public void removeSprintFromProject(UserDto userDto, int projectID, int sprintID, HttpServletRequest request) {
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
-        sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+        sprintsRepository.doesSprintExistInProject(sprintID, projectID, request);
 
         sprintsRepository.removeSprintFromProject(sprintID, projectID);
 
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
-    public @NotNull SprintsInProjectDto getAllSprintsForProject(UserDto userDto, int projectID, String contextPath) {
-        validateUserValidAndInsideValidProject(userDto, projectID);
+    public @NotNull SprintsInProjectDto getAllSprintsForProject(UserDto userDto, int projectID, HttpServletRequest request) {
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
         SprintsInProjectDto sprintsInProjectDto = sprintsRepository.getAllSprintsForProject(projectID);
-        sprintsInProjectDto.setLocations(contextPath);
+        sprintsInProjectDto.setLocations(request.getContextPath());
 
         return sprintsInProjectDto;
     }
 
-    public @NotNull TasksInSprintDto getAllTasksInSprint(UserDto userDto, int projectID, int sprintID, String contextPath) {
-        validateUserValidAndInsideValidProject(userDto, projectID);
+    public @NotNull TasksInSprintDto getAllTasksInSprint(UserDto userDto, int projectID, int sprintID, HttpServletRequest request) {
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
-        sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+        sprintsRepository.doesSprintExistInProject(sprintID, projectID, request);
 
         TasksInSprintDto tasksInSprintDto = sprintsRepository.getAllTasksInSprint(projectID, sprintID);
-        tasksInSprintDto.setSprintLocation(contextPath, projectID);
+        tasksInSprintDto.setSprintLocation(request.getContextPath(), projectID);
         return tasksInSprintDto;
     }
 
@@ -88,9 +92,9 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
             int sprintID,
             @NotNull EditSprintDto editSprintDto,
             HttpServletRequest request) {
-        validateUserValidAndInsideValidProject(userDto, projectID);
+        validateUserValidAndInsideValidProject(userDto, projectID, request);
 
-        SprintsRecord sprintToEdit = sprintsRepository.doesSprintExistInProject(sprintID, projectID);
+        SprintsRecord sprintToEdit = sprintsRepository.doesSprintExistInProject(sprintID, projectID, request);
 
         modifySprintName(sprintToEdit, projectID, editSprintDto, request);
         if (editSprintDto.getStartDate() != null && editSprintDto.getEndDate() != null) {
@@ -119,7 +123,7 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         if (editSprintDto.getSprintName() != null &&
                 !editSprintDto.getSprintName().equals(sprintToEdit.getSprintName())) {
 
-            sprintsRepository.isSprintNameInProject(projectID, editSprintDto.getSprintName());
+            sprintsRepository.isSprintNameInProject(projectID, editSprintDto.getSprintName(), request);
 
             sprintToEdit.setSprintName(editSprintDto.getSprintName());
             log.info("Sprint name modified. | RID: {}", request.getAttribute(RID));
@@ -234,11 +238,14 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
     }
 
     @Override
-    public @NotNull BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID) {
-        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto);
+    public @NotNull BeaverusersRecord validateUserValidAndInsideValidProject(
+            UserDto userDto,
+            int projectID,
+            HttpServletRequest request) {
+        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto, request);
 
         // Validate user in project and project exists
-        projectUsersRepository.isUserInProjectAndDoesProjectExist(beaverusersRecord.getUserId(), projectID);
+        projectUsersRepository.isUserInProjectAndDoesProjectExist(beaverusersRecord.getUserId(), projectID, request);
 
         return beaverusersRecord;
     }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/SprintsService.java
@@ -1,8 +1,11 @@
 package org.opm.busybeaver.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Sprints.*;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Sprints.SprintsExceptions;
 import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
@@ -15,11 +18,13 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 
 @Service
+@Slf4j
 public final class SprintsService implements ValidateUserAndProjectInterface {
     private final UsersRepository usersRepository;
     private final SprintsRepository sprintsRepository;
     private final ProjectUsersRepository projectUsersRepository;
     private final ProjectsRepository projectsRepository;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public SprintsService(
@@ -34,7 +39,7 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         this.projectsRepository = projectsRepository;
     }
 
-    public SprintSummaryDto addSprint(UserDto userDto, int projectID, NewSprintDto newSprintDto, String contextPath) {
+    public @NotNull SprintSummaryDto addSprint(UserDto userDto, int projectID, @NotNull NewSprintDto newSprintDto, String contextPath) {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         sprintsRepository.isSprintNameInProject(projectID, newSprintDto.sprintName());
@@ -58,7 +63,7 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
-    public SprintsInProjectDto getAllSprintsForProject(UserDto userDto, int projectID, String contextPath) {
+    public @NotNull SprintsInProjectDto getAllSprintsForProject(UserDto userDto, int projectID, String contextPath) {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         SprintsInProjectDto sprintsInProjectDto = sprintsRepository.getAllSprintsForProject(projectID);
@@ -67,7 +72,7 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         return sprintsInProjectDto;
     }
 
-    public TasksInSprintDto getAllTasksInSprint(UserDto userDto, int projectID, int sprintID, String contextPath) {
+    public @NotNull TasksInSprintDto getAllTasksInSprint(UserDto userDto, int projectID, int sprintID, String contextPath) {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         sprintsRepository.doesSprintExistInProject(sprintID, projectID);
@@ -77,19 +82,24 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         return tasksInSprintDto;
     }
 
-    public boolean modifySprint(UserDto userDto, int projectID, int sprintID, @NotNull EditSprintDto editSprintDto) {
+    public boolean modifySprint(
+            UserDto userDto,
+            int projectID,
+            int sprintID,
+            @NotNull EditSprintDto editSprintDto,
+            HttpServletRequest request) {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         SprintsRecord sprintToEdit = sprintsRepository.doesSprintExistInProject(sprintID, projectID);
 
-        modifySprintName(sprintToEdit, projectID, editSprintDto);
+        modifySprintName(sprintToEdit, projectID, editSprintDto, request);
         if (editSprintDto.getStartDate() != null && editSprintDto.getEndDate() != null) {
             // Compare the new possible dates against each other
-            modifySprintStartAndEndDate(sprintToEdit, editSprintDto);
+            modifySprintStartAndEndDate(sprintToEdit, editSprintDto, request);
         } else {
             // Compare the new possible dates against their older partner dates
-            modifySprintStartDate(sprintToEdit, editSprintDto);
-            modifySprintEndDate(sprintToEdit, editSprintDto);
+            modifySprintStartDate(sprintToEdit, editSprintDto, request);
+            modifySprintEndDate(sprintToEdit, editSprintDto, request);
         }
 
         boolean isSprintUpdated = sprintToEdit.changed();
@@ -101,17 +111,28 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
         return isSprintUpdated;
     }
 
-    private void modifySprintName(SprintsRecord sprintToEdit, int projectID, @NotNull EditSprintDto editSprintDto) {
+    private void modifySprintName(
+            SprintsRecord sprintToEdit,
+            int projectID,
+            @NotNull EditSprintDto editSprintDto,
+            HttpServletRequest request) {
         if (editSprintDto.getSprintName() != null &&
                 !editSprintDto.getSprintName().equals(sprintToEdit.getSprintName())) {
 
             sprintsRepository.isSprintNameInProject(projectID, editSprintDto.getSprintName());
 
             sprintToEdit.setSprintName(editSprintDto.getSprintName());
+            log.info("Sprint name modified. | RID: {}", request.getAttribute(RID));
+        } else {
+            log.info("Sprint name not modified. | RID: {}", request.getAttribute(RID));
         }
+
     }
 
-    private void modifySprintStartAndEndDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+    private void modifySprintStartAndEndDate(
+            SprintsRecord sprintToEdit,
+            @NotNull EditSprintDto editSprintDto,
+            HttpServletRequest request)
             throws SprintsExceptions.SprintDatesInvalid {
 
         LocalDate newStartDate = editSprintDto.getStartDate();
@@ -119,56 +140,101 @@ public final class SprintsService implements ValidateUserAndProjectInterface {
 
         // Just getting rid of the IDE saying potential nullability ahead...
         if (newStartDate == null || newEndDate == null) return;
+        log.info("New start date: {} | New end date: {} | RID: {}", newStartDate, newEndDate, request.getAttribute(RID));
 
         if (!newStartDate.isBefore(newEndDate)) {
-            throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+            SprintsExceptions.SprintDatesInvalid sprintDatesInvalid =
+                    new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.SPRINT_DATES_INVALID,
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    sprintDatesInvalid);
+
+            throw sprintDatesInvalid;
         }
 
         if (!newStartDate.isEqual(sprintToEdit.getBeginDate())) {
             sprintToEdit.setBeginDate(newStartDate);
+            log.info("Set the new sprint start date. | RID: {}", request.getAttribute(RID));
         }
 
         if (!newEndDate.isEqual(sprintToEdit.getEndDate())) {
             sprintToEdit.setEndDate(newEndDate);
+            log.info("Set the new sprint end date. | RID: {}", request.getAttribute(RID));
         }
     }
 
-    private void modifySprintStartDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+    private void modifySprintStartDate(
+            SprintsRecord sprintToEdit,
+            @NotNull EditSprintDto editSprintDto,
+            HttpServletRequest request)
         throws SprintsExceptions.SprintDatesInvalid {
         if (editSprintDto.getStartDate() != null) {
             LocalDate newStartDate = editSprintDto.getStartDate();
             LocalDate currentEndDate = sprintToEdit.getEndDate();
+            log.info("New start date: {} | Current end date: {} | RID: {}",
+                    newStartDate,
+                    currentEndDate,
+                    request.getAttribute(RID));
 
             if (!newStartDate.isBefore(currentEndDate)) {
-                throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+                SprintsExceptions.SprintDatesInvalid sprintDatesInvalid =
+                        new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+
+                log.error("{}. | RID: {} {}",
+                        ErrorMessageConstants.SPRINT_DATES_INVALID.getValue(),
+                        request.getAttribute(RID),
+                        System.lineSeparator(),
+                        sprintDatesInvalid);
+
+                throw sprintDatesInvalid;
             }
 
             if (!newStartDate.isEqual(sprintToEdit.getBeginDate())) {
                 sprintToEdit.setBeginDate(newStartDate);
+                log.info("Set new sprint start date. | RID: {}", request.getAttribute(RID));
             }
         }
     }
 
-    private void modifySprintEndDate(SprintsRecord sprintToEdit, @NotNull EditSprintDto editSprintDto)
+    private void modifySprintEndDate(
+            SprintsRecord sprintToEdit,
+            @NotNull EditSprintDto editSprintDto,
+            HttpServletRequest request)
         throws SprintsExceptions.SprintDatesInvalid {
 
         if (editSprintDto.getEndDate() != null) {
-            LocalDate newStartDate = editSprintDto.getStartDate();
             LocalDate newEndDate = editSprintDto.getEndDate();
             LocalDate currentStartDate = sprintToEdit.getBeginDate();
+            log.info("New end date: {} | Current start date: {} | RID: {}",
+                    newEndDate,
+                    currentStartDate,
+                    request.getAttribute(RID));
 
             if (!currentStartDate.isBefore(newEndDate)) {
-                throw new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+                SprintsExceptions.SprintDatesInvalid sprintDatesInvalid =
+                        new SprintsExceptions.SprintDatesInvalid(ErrorMessageConstants.SPRINT_DATES_INVALID.getValue());
+
+                log.error("{}. | RID: {} {}",
+                        ErrorMessageConstants.SPRINT_DATES_INVALID.getValue(),
+                        request.getAttribute(RID),
+                        System.lineSeparator(),
+                        sprintDatesInvalid);
+
+                throw sprintDatesInvalid;
             }
 
             if (!newEndDate.isEqual(sprintToEdit.getEndDate())) {
                 sprintToEdit.setEndDate(newEndDate);
+                log.info("Set new sprint end date. | RID: {}", request.getAttribute(RID));
             }
         }
     }
 
     @Override
-    public BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID) {
+    public @NotNull BeaverusersRecord validateUserValidAndInsideValidProject(UserDto userDto, int projectID) {
         BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto);
 
         // Validate user in project and project exists

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TasksService.java
@@ -1,10 +1,13 @@
 package org.opm.busybeaver.service;
 
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.dto.Tasks.NewTaskDtoExtended;
 import org.opm.busybeaver.dto.Tasks.TaskCreatedDto;
 import org.opm.busybeaver.dto.Tasks.TaskDetailsDto;
 import org.opm.busybeaver.dto.Users.UserDto;
+import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.DatabaseConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.enums.TaskFields;
@@ -25,6 +28,7 @@ import java.util.Map;
 
 
 @Service
+@Slf4j
 public class TasksService implements ValidateUserAndProjectInterface {
     private final ProjectsRepository projectsRepository;
     private final UsersRepository usersRepository;
@@ -32,6 +36,7 @@ public class TasksService implements ValidateUserAndProjectInterface {
     private final ColumnsRepository columnsRepository;
     private final SprintsRepository sprintsRepository;
     private final ProjectUsersRepository projectUsersRepository;
+    private static final String RID = BusyBeavConstants.REQUEST_ID.getValue();
 
     @Autowired
     public TasksService(
@@ -51,7 +56,7 @@ public class TasksService implements ValidateUserAndProjectInterface {
     }
 
     public TaskCreatedDto addTask(
-            NewTaskDtoExtended newTaskDto,
+            @NotNull NewTaskDtoExtended newTaskDto,
             UserDto userDto,
             int projectID,
             String contextPath) {
@@ -120,7 +125,12 @@ public class TasksService implements ValidateUserAndProjectInterface {
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
-    public boolean modifyTask(UserDto userDto, int projectID, int taskID, Map<String, Object> fieldsToEdit)
+    public boolean modifyTask(
+            UserDto userDto,
+            int projectID,
+            int taskID,
+            @NotNull Map<String, Object> fieldsToEdit,
+            HttpServletRequest request)
         throws TasksExceptions.TaskFieldNotFound {
 
         if (fieldsToEdit.isEmpty()) return false;
@@ -128,17 +138,26 @@ public class TasksService implements ValidateUserAndProjectInterface {
         validateUserValidAndInsideValidProject(userDto, projectID);
 
         if (!TaskFields.areTaskFieldsValid(fieldsToEdit)) {
-            throw new TasksExceptions.TaskFieldNotFound(ErrorMessageConstants.TASK_FIELD_NOT_FOUND.getValue());
+            TasksExceptions.TaskFieldNotFound taskFieldNotFound =
+                    new TasksExceptions.TaskFieldNotFound(ErrorMessageConstants.TASK_FIELD_NOT_FOUND.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.TASK_FIELD_NOT_FOUND.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    taskFieldNotFound);
+
+            throw taskFieldNotFound;
         }
 
         TasksRecord taskToEdit = tasksRepository.doesTaskExistInProject(taskID, projectID);
 
-        modifyTaskPriority(taskToEdit, fieldsToEdit);
-        modifyTaskDueDate(taskToEdit, fieldsToEdit);
-        modifyTaskSprintID(taskToEdit, fieldsToEdit, projectID);
-        modifyTaskAssignedTo(taskToEdit, fieldsToEdit, projectID);
-        modifyTaskDescription(taskToEdit, fieldsToEdit);
-        modifyTaskTitle(taskToEdit, fieldsToEdit);
+        modifyTaskPriority(taskToEdit, fieldsToEdit, request);
+        modifyTaskDueDate(taskToEdit, fieldsToEdit, request);
+        modifyTaskSprintID(taskToEdit, fieldsToEdit, projectID, request);
+        modifyTaskAssignedTo(taskToEdit, fieldsToEdit, projectID, request);
+        modifyTaskDescription(taskToEdit, fieldsToEdit, request);
+        modifyTaskTitle(taskToEdit, fieldsToEdit, request);
 
         boolean taskUpdated = taskToEdit.changed();
         if (taskUpdated) {
@@ -163,14 +182,27 @@ public class TasksService implements ValidateUserAndProjectInterface {
         projectsRepository.updateLastUpdatedForProject(projectID);
     }
 
-    private void modifyTaskPriority(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+    private void modifyTaskPriority(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            HttpServletRequest request)
         throws TasksExceptions.InvalidTaskPriority {
 
         final String PRIORITY = TaskFields.priority.toString();
         if (fieldsToEdit.containsKey(PRIORITY) && fieldsToEdit.get(PRIORITY) != null) {
+            log.info("Changing task priority to: {} | RID: {}", fieldsToEdit.get(PRIORITY), request.getAttribute(RID));
 
             if (!TaskFields.priorityFields.isPriorityFieldValid(fieldsToEdit.get(PRIORITY).toString())) {
-                throw new TasksExceptions.InvalidTaskPriority(ErrorMessageConstants.TASK_PRIORITY_INVALID.getValue());
+                TasksExceptions.InvalidTaskPriority taskPriorityException =
+                        new TasksExceptions.InvalidTaskPriority(ErrorMessageConstants.TASK_PRIORITY_INVALID.getValue());
+
+                log.error("{}. | RID: {} {}",
+                        ErrorMessageConstants.TASK_PRIORITY_INVALID,
+                        request.getAttribute(RID),
+                        System.lineSeparator(),
+                        taskPriorityException);
+
+                throw taskPriorityException;
             }
 
             if (taskToEdit.getPriority() == null || !taskToEdit.getPriority().equals(fieldsToEdit.get(PRIORITY).toString())) {
@@ -179,7 +211,10 @@ public class TasksService implements ValidateUserAndProjectInterface {
         }
     }
 
-    private void modifyTaskDueDate(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+    private void modifyTaskDueDate(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            HttpServletRequest request)
         throws TasksExceptions.InvalidTaskDueDate {
         // Task due date can be set to NULL, indicated by incoming JSON field for dueDate being set to null
 
@@ -189,9 +224,19 @@ public class TasksService implements ValidateUserAndProjectInterface {
                 DateTimeFormatter dueDateFormat = DateTimeFormatter.ISO_LOCAL_DATE;
                 try {
                     LocalDate dueDate = LocalDate.parse(fieldsToEdit.get(DUE_DATE).toString(), dueDateFormat);
+                    log.info("Changing task due date to: {} | RID: {}", dueDate, request.getAttribute(RID));
                     if (dueDate.isBefore(LocalDate.now())) {
-                        throw new TasksExceptions.InvalidTaskDueDate(
-                                ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+                        TasksExceptions.InvalidTaskDueDate taskDueDateException =
+                                new TasksExceptions.InvalidTaskDueDate(
+                                        ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+
+                        log.error("{}. | RID: {} {}",
+                                ErrorMessageConstants.TASK_DUE_DATE_INVALID,
+                                request.getAttribute(RID),
+                                System.lineSeparator(),
+                                taskDueDateException);
+
+                        throw taskDueDateException;
                     }
 
                     if (taskToEdit.getDueDate() == null || !taskToEdit.getDueDate().isEqual(dueDate)) {
@@ -199,8 +244,17 @@ public class TasksService implements ValidateUserAndProjectInterface {
                     }
 
                 } catch (DateTimeParseException dateTimeParseException) {
-                    throw new TasksExceptions.InvalidTaskDueDate(
-                            ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+                    TasksExceptions.InvalidTaskDueDate taskDueDateException =
+                            new TasksExceptions.InvalidTaskDueDate(
+                                    ErrorMessageConstants.TASK_DUE_DATE_INVALID.getValue());
+
+                    log.error("{}. | RID: {} {}",
+                            ErrorMessageConstants.TASK_DUE_DATE_INVALID,
+                            request.getAttribute(RID),
+                            System.lineSeparator(),
+                            taskDueDateException);
+
+                    throw taskDueDateException;
                 }
             } else {
                 if (taskToEdit.getDueDate() != null) {
@@ -210,12 +264,17 @@ public class TasksService implements ValidateUserAndProjectInterface {
         }
     }
 
-    private void modifyTaskSprintID(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit, int projectID)
+    private void modifyTaskSprintID(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            int projectID,
+            HttpServletRequest request)
         throws SprintsExceptions.SprintDoesNotExistInProject {
         // Task sprintID can be set to NULL, indicated by incoming JSON field for sprintID being set to null
 
         final String SPRINT_ID = TaskFields.sprintID.toString();
         if (fieldsToEdit.containsKey(SPRINT_ID)) {
+            log.info("Changing task sprint to: {} | RID: {}", fieldsToEdit.get(SPRINT_ID), request.getAttribute(RID));
             if (fieldsToEdit.get(SPRINT_ID) != null) {
                 try {
                     int sprintID = Integer.parseInt(fieldsToEdit.get(SPRINT_ID).toString());
@@ -226,7 +285,17 @@ public class TasksService implements ValidateUserAndProjectInterface {
                     }
 
                 } catch (IllegalArgumentException illegalArgumentException) {
-                    throw new SprintsExceptions.SprintDoesNotExistInProject(ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue());
+                    SprintsExceptions.SprintDoesNotExistInProject sprintDoesNotExistInProject =
+                            new SprintsExceptions.SprintDoesNotExistInProject(
+                                    ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue());
+
+                    log.error("{}. | RID: {} {}",
+                            ErrorMessageConstants.SPRINT_NOT_IN_PROJECT.getValue(),
+                            request.getAttribute(RID),
+                            System.lineSeparator(),
+                            sprintDoesNotExistInProject);
+
+                    throw sprintDoesNotExistInProject;
                 }
             } else {
                 if (taskToEdit.getSprintId() != null) {
@@ -236,7 +305,10 @@ public class TasksService implements ValidateUserAndProjectInterface {
         }
     }
 
-    private void modifyTaskDescription(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+    private void modifyTaskDescription(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            HttpServletRequest request)
         throws TasksExceptions.InvalidTaskDescription {
         // Task description can be set to NULL, indicated by incoming JSON field for description being set to null
 
@@ -245,7 +317,17 @@ public class TasksService implements ValidateUserAndProjectInterface {
             Object description = fieldsToEdit.get(DESCRIPTION);
             if (description != null) {
                 if (!(description instanceof String) || (((String) description).length() > 500)) {
-                    throw new TasksExceptions.InvalidTaskDescription(ErrorMessageConstants.TASK_DESCRIPTION_INVALID.getValue());
+                    TasksExceptions.InvalidTaskDescription invalidTaskDescription =
+                            new TasksExceptions.InvalidTaskDescription(
+                                    ErrorMessageConstants.TASK_DESCRIPTION_INVALID.getValue());
+
+                    log.error("{}. | RID: {} {}",
+                            ErrorMessageConstants.TASK_DESCRIPTION_INVALID.getValue(),
+                            request.getAttribute(RID),
+                            System.lineSeparator(),
+                            invalidTaskDescription);
+
+                    throw invalidTaskDescription;
                 }
                 if (taskToEdit.getDescription() == null || !taskToEdit.getDescription().equals(description)) {
                     taskToEdit.setDescription((String) description);
@@ -258,14 +340,26 @@ public class TasksService implements ValidateUserAndProjectInterface {
         }
     }
 
-    private void modifyTaskTitle(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit)
+    private void modifyTaskTitle(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            HttpServletRequest request)
         throws TasksExceptions.InvalidTaskTitle {
 
         final String TITLE = TaskFields.title.toString();
         if (fieldsToEdit.containsKey(TITLE) && fieldsToEdit.get(TITLE) != null) {
             Object title = fieldsToEdit.get(TITLE);
             if (!(title instanceof String) || (((((String) title).length() > 50) || ((String) title).length() < 3))) {
-                throw new TasksExceptions.InvalidTaskTitle(ErrorMessageConstants.TASK_TITLE_INVALID.getValue());
+                TasksExceptions.InvalidTaskTitle invalidTaskTitle =
+                        new TasksExceptions.InvalidTaskTitle(ErrorMessageConstants.TASK_TITLE_INVALID.getValue());
+
+                log.error("{}. | RID: {} {}",
+                        ErrorMessageConstants.TASK_TITLE_INVALID.getValue(),
+                        request.getAttribute(RID),
+                        System.lineSeparator(),
+                        invalidTaskTitle);
+
+                throw invalidTaskTitle;
             }
 
             if (!taskToEdit.getTitle().equals(title)) {
@@ -274,7 +368,11 @@ public class TasksService implements ValidateUserAndProjectInterface {
         }
     }
 
-    private void modifyTaskAssignedTo(TasksRecord taskToEdit, @NotNull Map<String, Object> fieldsToEdit, int projectID)
+    private void modifyTaskAssignedTo(
+            TasksRecord taskToEdit,
+            @NotNull Map<String, Object> fieldsToEdit,
+            int projectID,
+            HttpServletRequest request)
         throws ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent {
         // Task assignedTo can be set to NULL, indicated by incoming JSON field for assignedTo being set to null
 
@@ -290,8 +388,18 @@ public class TasksService implements ValidateUserAndProjectInterface {
                     }
 
                 } catch (IllegalArgumentException illegalArgumentException) {
-                    throw new ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent(
-                            ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue());
+                    ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent assignedToUserNotInProjectOrNonexistent =
+                            new ProjectUsersExceptions.AssignedToUserNotInProjectOrNonexistent(
+                                    ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue()
+                            );
+
+                    log.error("{}. | RID: {} {}",
+                            ErrorMessageConstants.ASSIGNED_TO_USER_NOT_IN_PROJECT_OR_USER_NOT_EXIST.getValue(),
+                            request.getAttribute(RID),
+                            System.lineSeparator(),
+                            assignedToUserNotInProjectOrNonexistent);
+
+                    throw assignedToUserNotInProjectOrNonexistent;
                 }
             } else {
                 if (taskToEdit.getAssignedTo() != null) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/UsersService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/UsersService.java
@@ -1,5 +1,6 @@
 package org.opm.busybeaver.service;
 
+import jakarta.servlet.http.HttpServletRequest;
 import org.opm.busybeaver.dto.Users.AuthenticatedUser;
 import org.opm.busybeaver.dto.Users.UserDto;
 import org.opm.busybeaver.enums.SuccessMessageConstants;
@@ -18,8 +19,8 @@ public class UsersService {
         this.usersRepository = usersRepository;
     }
 
-    public AuthenticatedUser getUserByEmailAndId(UserDto userDto) {
-        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto);
+    public AuthenticatedUser getUserByEmailAndId(UserDto userDto, HttpServletRequest request) {
+        BeaverusersRecord beaverusersRecord = usersRepository.getUserByEmailAndId(userDto, request);
 
         return new AuthenticatedUser(
                 beaverusersRecord.getUsername(),
@@ -27,8 +28,8 @@ public class UsersService {
         );
     }
 
-    public AuthenticatedUser registerUser(UserDto userDto) {
-        String newUsername = usersRepository.registerUser(userDto);
+    public AuthenticatedUser registerUser(UserDto userDto, HttpServletRequest request) {
+        String newUsername = usersRepository.registerUser(userDto, request);
 
         return new AuthenticatedUser(
                 newUsername,

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/utils/Utils.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/utils/Utils.java
@@ -1,15 +1,22 @@
 package org.opm.busybeaver.utils;
 
+import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 
+import java.time.Duration;
+import java.time.Instant;
 import java.util.HashMap;
 
 public final class Utils {
-    public static HashMap<String, Object> generateExceptionResponse(String message, Integer errorCode) {
+    public static @NotNull HashMap<String, Object> generateExceptionResponse(String message, Integer errorCode) {
         HashMap<String, Object> result = new HashMap<>();
         result.put(ErrorMessageConstants.MESSAGE.getValue(), message);
         result.put(ErrorMessageConstants.CODE.getValue(), errorCode);
 
         return result;
+    }
+
+    public static @NotNull Long calculateTimeLengthMillis(Instant startTime) {
+        return Duration.between(startTime, Instant.now()).toMillis();
     }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/utils/Utils.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/utils/Utils.java
@@ -3,8 +3,6 @@ package org.opm.busybeaver.utils;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 
-import java.time.Duration;
-import java.time.Instant;
 import java.util.HashMap;
 
 public final class Utils {
@@ -14,9 +12,5 @@ public final class Utils {
         result.put(ErrorMessageConstants.CODE.getValue(), errorCode);
 
         return result;
-    }
-
-    public static @NotNull Long calculateTimeLengthMillis(Instant startTime) {
-        return Duration.between(startTime, Instant.now()).toMillis();
     }
 }

--- a/backend/busybeaver/src/main/resources/application.properties
+++ b/backend/busybeaver/src/main/resources/application.properties
@@ -1,3 +1,5 @@
 server.servlet.context-path=/api
 spring.jackson.deserialization.accept-float-as-int=false
 spring.jackson.deserialization.fail-on-unknown-properties=true
+logging.logback.rollingpolicy.file-name-pattern=busybeaver.%d{yyyy-MM-dd}.%i.log
+logging.logback.rollingpolicy.max-history=10

--- a/backend/busybeaver/src/main/resources/application.properties
+++ b/backend/busybeaver/src/main/resources/application.properties
@@ -1,5 +1,3 @@
 server.servlet.context-path=/api
 spring.jackson.deserialization.accept-float-as-int=false
 spring.jackson.deserialization.fail-on-unknown-properties=true
-logging.logback.rollingpolicy.file-name-pattern=busybeaver.%d{yyyy-MM-dd}.%i.log
-logging.logback.rollingpolicy.max-history=10

--- a/backend/busybeaver/src/main/resources/logback-spring.xml
+++ b/backend/busybeaver/src/main/resources/logback-spring.xml
@@ -7,7 +7,6 @@
               class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">
             <Pattern>
-<!--                %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n-->
                 %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1}): %msg%n%throwable
             </Pattern>
         </layout>
@@ -20,7 +19,11 @@
                 class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
             <Pattern>%d %p %C{1} [%t] %m%n</Pattern>
         </encoder>
-
+        <filter class="ch.qos.logback.classic.filter.LevelFilter">
+                <level>DEBUG</level>
+                <onMatch>DENY</onMatch>
+                <onMismatch>ACCEPT</onMismatch>
+        </filter>
         <rollingPolicy
                 class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- rollover daily and when the file reaches 10 MegaBytes -->
@@ -39,5 +42,6 @@
         <appender-ref ref="Console" />
     </root>
 
+    <logger name="org.jooq" level="debug"/>
 
 </configuration>

--- a/backend/busybeaver/src/main/resources/logback-spring.xml
+++ b/backend/busybeaver/src/main/resources/logback-spring.xml
@@ -27,11 +27,13 @@
         <rollingPolicy
                 class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <!-- rollover daily and when the file reaches 10 MegaBytes -->
-            <fileNamePattern>${LOGS}/archived/busybeaver-logger-%d{yyyy-MM-dd}.%i.log
-            </fileNamePattern>
+            <fileNamePattern>${LOGS}/archived/busybeaver-logger-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+
             <timeBasedFileNamingAndTriggeringPolicy
                     class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
                 <maxFileSize>10MB</maxFileSize>
+                <maxHistory>60</maxHistory>
+                <totalSizeCap>2GB</totalSizeCap>
             </timeBasedFileNamingAndTriggeringPolicy>
         </rollingPolicy>
     </appender>

--- a/backend/busybeaver/src/main/resources/logback-spring.xml
+++ b/backend/busybeaver/src/main/resources/logback-spring.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <property name="LOGS" value="./logs" />
+
+    <appender name="Console"
+              class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+<!--                %d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n-->
+                %black(%d{ISO8601}) %highlight(%-5level) [%blue(%t)] %yellow(%C{1}): %msg%n%throwable
+            </Pattern>
+        </layout>
+    </appender>
+
+    <appender name="RollingFile"
+              class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${LOGS}/busybeaver-logger.log</file>
+        <encoder
+                class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+            <Pattern>%d %p %C{1} [%t] %m%n</Pattern>
+        </encoder>
+
+        <rollingPolicy
+                class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- rollover daily and when the file reaches 10 MegaBytes -->
+            <fileNamePattern>${LOGS}/archived/busybeaver-logger-%d{yyyy-MM-dd}.%i.log
+            </fileNamePattern>
+            <timeBasedFileNamingAndTriggeringPolicy
+                    class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
+                <maxFileSize>10MB</maxFileSize>
+            </timeBasedFileNamingAndTriggeringPolicy>
+        </rollingPolicy>
+    </appender>
+
+    <!-- LOG everything at INFO level -->
+    <root level="info">
+        <appender-ref ref="RollingFile" />
+        <appender-ref ref="Console" />
+    </root>
+
+
+</configuration>

--- a/backend/busybeaver/src/test/java/org/opm/busybeaver/BusybeaverApplicationTests.java
+++ b/backend/busybeaver/src/test/java/org/opm/busybeaver/BusybeaverApplicationTests.java
@@ -3,6 +3,7 @@ package org.opm.busybeaver;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.opm.busybeaver.config.FirebaseConfig;
+import org.slf4j.event.LoggingEvent;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
@@ -17,6 +18,9 @@ class BusybeaverApplicationTests {
 
     @MockBean
     private DataSource dataSource;
+
+    @MockBean
+    private LoggingEvent loggingEvent;
 
     @Test
     void contextLoads() {


### PR DESCRIPTION
Add logging to the RestAPI.

Logs to files in a newly created directory called `logs`, which will be stored under `backend/busybeaver/`

This directory is set to be ignored via the `gitignore`, and won't be added to source control.

The logging policy is to keep logs for 60 days. Each individual file is 10MB max, afterwards it is rolled into a new file. The total size of all logs cannot be more than 2GB. These may be changed in the future.

DEBUG level information may contain Personally Identifiable Information (PII), specifically through the jOOQ library performing the SQL requests. Debug information is not allowed to be stored in the log files.

Each HTTP request is given a UUID that is not associated with any PII. This is stored in each log line to be able to keep track of which request is being performed at which time.

Below are some examples.

![image](https://github.com/CS467-OPM-Site/OPM/assets/80492028/55d3a9ba-bc64-451a-a34d-47b802d6d0da)


Closes #71 