### PR TITLE
Add error response for an invalid or missing URL

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/enums/ErrorMessageConstants.java
@@ -4,6 +4,7 @@ public enum ErrorMessageConstants {
     ERROR_KEY_VAL("Error"),
     MESSAGE("message"),
     CODE("code"),
+    INVALID_RESOURCE("Resource or URL not found"),
     INVALID_ARGUMENT("Invalid argument"),
     USER_ALREADY_EXISTS("User already exists with those details"),
     USER_DOES_NOT_EXIST("User does not exist"),

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ValidationExceptionHandler.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/exceptions/ValidationExceptionHandler.java
@@ -11,6 +11,7 @@ import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.servlet.resource.NoResourceFoundException;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -67,4 +68,12 @@ public class ValidationExceptionHandler {
         return new ResponseEntity<>(null, HttpStatus.METHOD_NOT_ALLOWED);
     }
 
+    @ExceptionHandler(NoResourceFoundException.class)
+    public ResponseEntity<?> resourceNotFound() {
+        return new ResponseEntity<>(
+                generateExceptionResponse(
+                        ErrorMessageConstants.INVALID_RESOURCE.getValue(),
+                        HttpStatus.NOT_FOUND.value()),
+                HttpStatus.NOT_FOUND);
+    }
 }

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TeamsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TeamsRepository.java
@@ -42,20 +42,6 @@ public class TeamsRepository {
                     .returningResult(TEAMS.TEAM_NAME, TEAMS.TEAM_ID, TEAMS.TEAM_CREATOR)
                     .fetchSingleInto(TeamsRecord.class);
 
-//            if (newTeamRecord == null) {
-//                TeamsExceptions.TeamAlreadyExistsForUserException teamAlreadyExistsForUserException =
-//                        new TeamsExceptions.TeamAlreadyExistsForUserException(
-//                                ErrorMessageConstants.TEAM_ALREADY_EXISTS_FOR_USER.getValue());
-//
-//                log.error("{}. | RID: {} {}",
-//                        ErrorMessageConstants.TEAM_ALREADY_EXISTS_FOR_USER.getValue(),
-//                        request.getAttribute(RID),
-//                        System.lineSeparator(),
-//                        teamAlreadyExistsForUserException);
-//
-//                throw teamAlreadyExistsForUserException;
-//            }
-
             // Trigger option - Add the creator to the TeamUsers table, role of Creator
             create.insertInto(TEAMUSERS, TEAMUSERS.TEAM_ID, TEAMUSERS.USER_ID, TEAMUSERS.USER_TEAM_ROLE)
                     .values(newTeamRecord.getTeamId(), newTeamRecord.getTeamCreator(), DatabaseConstants.TEAMUSERS_CREATOR_ROLE.getValue())

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TeamsService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/TeamsService.java
@@ -184,7 +184,7 @@ public class TeamsService {
                             ErrorMessageConstants.TEAM_CREATOR_CANNOT_BE_REMOVED.getValue());
 
             log.error("{}. | RID: {} {}",
-                    ErrorMessageConstants.TEAM_CREATOR_CANNOT_BE_REMOVED,
+                    ErrorMessageConstants.TEAM_CREATOR_CANNOT_BE_REMOVED.getValue(),
                     request.getAttribute(RID),
                     System.lineSeparator(),
                     teamCreatorCannotBeRemovedException);


### PR DESCRIPTION
Add a 404 error response for an invalid or missing URL called on the RestAPI.

Plus some other quick changes, removing comments, ensuring error response for removing team creator is using the actual string value.