### PR TITLE
Allow user to add a column if no columns exist

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ColumnsRepository.java
@@ -183,10 +183,15 @@ public class ColumnsRepository {
         // SELECT MAX(Columns.column_index)
         // FROM Columns
         // WHERE Columns.project_id = projectID
-        int maxColumnIndex = create.select(max(COLUMNS.COLUMN_INDEX))
+        Short maxColumnIndex = create.select(max(COLUMNS.COLUMN_INDEX))
                 .from(COLUMNS)
                 .where(COLUMNS.PROJECT_ID.eq(projectID))
-                .fetchSingle().component1();
+                .fetchOne().component1();
+
+        if (maxColumnIndex == null) {
+                // When project has no columns, start the newest column at index 0
+                maxColumnIndex = -1;
+        }
 
         // Second, insert new column with next column index, making it last in-order column
         // INSERT INTO Columns (column_title, project_id, column_index)


### PR DESCRIPTION
Previously, the backend would attempt to find the last in-order column in a project in order to put the newest column after it positionally.

If a project did not have any columns, this in-order position would be null, which would cause the backend to fail when trying to add a column, since it could set a position based on null.

Hotfix to force the newest column to start at position 0 if no columns exist in the project.