### PR TITLE
Hotfix for team id equality in SQL jOOQ call f

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectsRepository.java
@@ -149,7 +149,7 @@ public class ProjectsRepository {
         return create.select(PROJECTS.PROJECT_NAME, PROJECTS.PROJECT_ID, PROJECTS.LAST_UPDATED, PROJECTS.TEAM_ID, TEAMS.TEAM_NAME)
                 .from(PROJECTS)
                 .join(TEAMS)
-                .on(TEAMS.TEAM_ID.eq(PROJECTS.PROJECT_ID))
+                .on(TEAMS.TEAM_ID.eq(PROJECTS.TEAM_ID))
                 .where(PROJECTS.PROJECT_ID.eq(projectID))
                 .fetchSingleInto(ProjectUserSummaryDto.class);
     }


### PR DESCRIPTION
On trying to get all project Users, received a `500` HTTP response code indicating a server failure.

Diving it, this SQL call was checking for equality on `team_id === team_id`, but mistakenly used `team_id === project_id` causing it to be unable to find the right records.

Hotfix coming through.