### PR TITLE
Ensure usage of userProjectID for task AssignedTo and comments

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -976,7 +976,7 @@ To delete the attribute, set the attribute to null in the request payload.
 
 > | http code     | content-type                      | response  | details |
 > |---------------|-----------------------------------|-----------|---------------------------------------------------------|
-> | `200`         | `application/json`                | `See below.` | **Includes a URI to the comment resource in the Location Header** |
+> | `201`         | `application/json`                | `See below.` | **Includes a URI to the comment resource in the Location Header** |
 > | `400`         | `application/json`                | `{"code":"400","message":"Comment cannot be empty"}` | Comment cannot be empty. |
 > | `403`         | `application/json`                | `{"code":"403","message":"User not in this project, or project does not exist"}` | User not in this project, or project does not exist. |
 > | `404`         | `application/json`                | `{"code":"404","message":"Given task does not exist in this project"}` | Task not found. |

--- a/backend/README.md
+++ b/backend/README.md
@@ -268,7 +268,8 @@ All endpoints should use this format as a prefix in their requests. For example,
 >                  "taskIndex": 0, # Used for sorting eventually, default to -1
 >                  "assignedTo": {
 >                        "username": "username-of-assignee",
->                        "userID": 1
+>                        "userID": 1,
+>                        "userProjectID": 1
 >                   }, # Or null
 >                  "sprint": {
 >                        "sprintID": 1,
@@ -717,7 +718,7 @@ All endpoints should use this format as a prefix in their requests. For example,
 >     "title": "Task 1",
 >     "description": "This is another task!", # Optional - a description of only spaces is considered null
 >     "columnID": 1,                          # Optional, defaults to first in-order column if not included
->     "assignedTo": 1,                        # Optional, ID of the user who it is being assigned to, or null
+>     "assignedTo": 1,                        # Optional, userProjectID of the user who it is being assigned to, or null
 >     "dueDate": "2024-11-03",                # Optional, in format "yyyy-MM-dd"
 >     "priority": "High",                     # Optional, must be one of: 'High', 'Medium', 'Low', 'None', defaults to 'None' 
 >     "sprintID": 1,                          # Optional
@@ -799,7 +800,8 @@ All endpoints should use this format as a prefix in their requests. For example,
 >     "description": "This is a task!",
 >     "assignedTo": {               # Or null
 >           "username": "username-of-assignee",
->           "userID": 1
+>           "userID": 1,
+>           "userProjectID": 1
 >      },       
 >     "priority": "High",
 >     "dueDate": "2023-10-31"       # Or null,
@@ -854,7 +856,7 @@ To delete the attribute, set the attribute to null in the request payload.
 > {
 >     "title": "New Title",                     # Optional - note that a title is mandatory for a task, so no possibility of deleting a title
 >     "description": "This is another task!",   # Optional
->     "assignedTo": 1,                          # Optional, ID of the user who it is being assigned to
+>     "assignedTo": 1,                          # Optional, userProjectID of the user who it is being assigned to
 >     "priority": "High",                       # Optional, must be one of 'High', 'Medium', 'Low', 'None'
 >     "sprintID": 1,                            # Optional, ID of sprint to change to
 >     "dueDate": "2024-08-08",                  # Optional, new due date
@@ -1240,7 +1242,8 @@ Sprints are ordered in ascending order by sprint end date.
 >            },
 >           "assignedTo": {
 >                 "username": "username-of-assignee",
->                 "userID": 1
+>                 "userID": 1,
+>                 "userProjectID": 1
 >            } or null,       
 >           "taskLocation": "/api/v1/projects/1/tasks/1",
 >      },
@@ -1259,7 +1262,8 @@ Sprints are ordered in ascending order by sprint end date.
 >            },
 >           "assignedTo": {
 >                 "username": "username-of-assignee",
->                 "userID": 1
+>                 "userID": 1,
+>                 "userProjectID": 1
 >            } or null,       
 >           "taskLocation": "/api/v1/projects/1/tasks/2",
 >      },

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/CommentsController.java
@@ -34,7 +34,7 @@ public final class CommentsController implements GetUserFromBearerTokenInterface
     @Autowired
     public CommentsController(CommentsService commentsService) { this.commentsService = commentsService; }
 
-    @PostMapping(PROJECTS_PATH + "/{projectID}" + TASK_PATH + "/{taskID}")
+    @PostMapping(PROJECTS_PATH + "/{projectID}" + TASK_PATH + "/{taskID}" + COMMENT_PATH)
     public @NotNull CommentInTaskDto addCommentToTask(
             @NotNull HttpServletRequest request,
             @Valid @RequestBody NewCommentBodyDto newCommentBodyDto,

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskBasicInSprintDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskBasicInSprintDto.java
@@ -1,11 +1,8 @@
 package org.opm.busybeaver.dto.Tasks;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.opm.busybeaver.dto.Columns.ColumnDto;
 import org.opm.busybeaver.dto.Columns.ColumnInTaskDto;
 import org.opm.busybeaver.dto.Interfaces.TaskBasicInterface;
-import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
-import org.opm.busybeaver.dto.Users.UserSummaryDto;
+import org.opm.busybeaver.dto.ProjectUsers.ProjectUserShortDto;
 import org.opm.busybeaver.enums.BusyBeavPaths;
 
 import javax.annotation.Nullable;
@@ -22,15 +19,16 @@ public final class TaskBasicInSprintDto implements TaskBasicInterface {
     private final String description;
     private ColumnInTaskDto column;
     @Nullable
-    private UserSummaryDto assignedTo;
+    private ProjectUserShortDto assignedTo;
     private String taskLocation;
 
     @ConstructorProperties({
             "title", "task_id", "priority", "due_date", "description", "comments",
-            "assigned_to", "username", "column_index", "column_title", "column_id"})
+            "username", "user_project_id", "user_id",
+            "column_index", "column_title", "column_id"})
     public TaskBasicInSprintDto(
             String title, int taskID, String priority, @Nullable LocalDate dueDate, String description, int comments,
-            @Nullable Integer assignedToId, @Nullable String username,
+            @Nullable String username, @Nullable Integer userProjectID, @Nullable Integer userID,
             int columnIndex, String columnTitle, int columnID) {
 
         this.title = title;
@@ -42,8 +40,8 @@ public final class TaskBasicInSprintDto implements TaskBasicInterface {
 
         this.column = new ColumnInTaskDto(columnTitle, columnID, columnIndex);
 
-        if (assignedToId != null && username != null) {
-            this.assignedTo = new UserSummaryDto(username, assignedToId);
+        if (username != null && userProjectID != null && userID != null) {
+            this.assignedTo = new ProjectUserShortDto(username, userID, userProjectID);
         }
     }
 
@@ -86,7 +84,7 @@ public final class TaskBasicInSprintDto implements TaskBasicInterface {
     }
 
     @Nullable
-    public UserSummaryDto getAssignedTo() {
+    public ProjectUserShortDto getAssignedTo() {
         return assignedTo;
     }
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskDetailsDto.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/dto/Tasks/TaskDetailsDto.java
@@ -3,8 +3,8 @@ package org.opm.busybeaver.dto.Tasks;
 import org.opm.busybeaver.dto.Columns.ColumnInTaskDto;
 import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
 import org.opm.busybeaver.dto.Interfaces.TaskBasicInterface;
+import org.opm.busybeaver.dto.ProjectUsers.ProjectUserShortDto;
 import org.opm.busybeaver.dto.Sprints.SprintSummaryDto;
-import org.opm.busybeaver.dto.Users.UserSummaryDto;
 import org.opm.busybeaver.enums.BusyBeavPaths;
 
 import javax.annotation.Nullable;
@@ -20,7 +20,7 @@ public final class TaskDetailsDto implements TaskBasicInterface {
     private final String priority;
     private final ColumnInTaskDto column;
     @Nullable
-    private UserSummaryDto assignedTo;
+    private ProjectUserShortDto assignedTo;
     @Nullable
     private SprintSummaryDto sprint;
     private List<CommentInTaskDto> comments;
@@ -31,11 +31,11 @@ public final class TaskDetailsDto implements TaskBasicInterface {
 
     @ConstructorProperties({"task_id", "title", "description", "priority", "due_date",
                             "column_id", "column_title", "column_index",
-                            "user_id", "username",
+                            "user_project_id", "user_id", "username",
                             "sprint_id", "begin_date", "end_date", "sprint_name"})
     public TaskDetailsDto(int taskID, String title, @Nullable String description, String priority, LocalDate dueDate,
                           int columnID, String columnTitle, int columnIndex,
-                          Integer userID, String username,
+                          Integer userProjectID, Integer userID, String username,
                           Integer sprintID, LocalDate startDate, LocalDate endDate, String sprintName) {
         this.taskID = taskID;
         this.title = title;
@@ -46,7 +46,7 @@ public final class TaskDetailsDto implements TaskBasicInterface {
         this.column = new ColumnInTaskDto(columnTitle, columnID, columnIndex);
 
         if (userID != null && username != null) {
-            this.assignedTo = new UserSummaryDto(username, userID);
+            this.assignedTo = new ProjectUserShortDto(username, userID, userProjectID);
         }
 
         if (sprintID != null) {
@@ -105,7 +105,7 @@ public final class TaskDetailsDto implements TaskBasicInterface {
     }
 
     @Nullable
-    public UserSummaryDto getAssignedTo() {
+    public ProjectUserShortDto getAssignedTo() {
         return assignedTo;
     }
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/CommentsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/CommentsRepository.java
@@ -7,6 +7,7 @@ import org.jooq.DSLContext;
 import org.jooq.Record3;
 import org.opm.busybeaver.dto.Comments.CommentInTaskDto;
 import org.opm.busybeaver.dto.Comments.NewCommentBodyDto;
+import org.opm.busybeaver.dto.ProjectUsers.ProjectUserShortDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.Comments.CommentsExceptions;
@@ -37,28 +38,28 @@ public class CommentsRepository {
     public CommentInTaskDto addComment(
             int taskID,
             @NotNull NewCommentBodyDto newCommentBodyDto,
-            BeaverusersRecord commenter) {
+            ProjectUserShortDto commenter) {
         Record3<Integer, String, LocalDateTime> newComment = create.insertInto(COMMENTS, COMMENTS.USER_ID, COMMENTS.TASK_ID, COMMENTS.COMMENT_BODY)
-                .values(commenter.getUserId(), taskID, newCommentBodyDto.commentBody())
+                .values(commenter.userProjectID(), taskID, newCommentBodyDto.commentBody())
                 .returningResult(COMMENTS.COMMENT_ID, COMMENTS.COMMENT_BODY, COMMENTS.COMMENT_CREATED)
                 .fetchSingle();
 
         return new CommentInTaskDto(
                 newComment.getValue(COMMENTS.COMMENT_ID),
                 newComment.getValue(COMMENTS.COMMENT_BODY),
-                commenter.getUsername(),
-                commenter.getUserId(),
+                commenter.username(),
+                commenter.userProjectID(),
                 newComment.getValue(COMMENTS.COMMENT_CREATED));
     }
 
-    public CommentsRecord doesCommentExistOnTask(int taskID, int commentID, int userID, HttpServletRequest request)
+    public CommentsRecord doesCommentExistOnTask(int taskID, int commentID, int userProjectID, HttpServletRequest request)
             throws CommentsExceptions.CommentDoesNotExistOnTask,
             CommentsExceptions.UserDidNotLeaveThisComment {
         //  SELECT Comments.comment_id
         //  FROM Comments
         //  WHERE Comments.comment_id = commentID
         //  AND Comments.task_id = taskID
-        //  AND Comments.user_id = userID;
+        //  AND Comments.user_id = userProjectID;
 
         CommentsRecord commentOnTask =
                 create.selectFrom(COMMENTS)
@@ -80,7 +81,7 @@ public class CommentsRepository {
             throw commentDoesNotExistOnTask;
         }
 
-        if (commentOnTask.getUserId() != userID) {
+        if (commentOnTask.getUserId() != userProjectID) {
             CommentsExceptions.UserDidNotLeaveThisComment userDidNotLeaveThisComment =
                     new CommentsExceptions.UserDidNotLeaveThisComment(
                             ErrorMessageConstants.USER_DID_NOT_LEAVE_THIS_COMMENT.getValue());
@@ -96,15 +97,15 @@ public class CommentsRepository {
         return commentOnTask;
     }
 
-    public void deleteComment(int taskID, int commentID, int userID) {
+    public void deleteComment(int taskID, int commentID, int userProjectID) {
         // DELETE FROM Comments
         // WHERE Comments.task_id = taskID
         // AND Comments.comment_id = commentID
-        // AND Comments.user_id = userID;
+        // AND Comments.user_id = userProjectID;
         create.deleteFrom(COMMENTS)
                 .where(COMMENTS.TASK_ID.eq(taskID))
                 .and(COMMENTS.COMMENT_ID.eq(commentID))
-                .and(COMMENTS.USER_ID.eq(userID))
+                .and(COMMENTS.USER_ID.eq(userProjectID))
                 .execute();
     }
 

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
@@ -38,14 +38,16 @@ public class ProjectUsersRepository {
         // SELECT BeaverUsers.username, Project ProjectUsers.user_id, ProjectUsers.user_project_id
         // FROM ProjectUsers
         // JOIN BeaverUsers
-        // ON ProjectUsers.user_id = user.userID
-        // WHERE ProjectUsers.project_id = projectid;
+        // ON ProjectUsers.user_id = BeaverUsers.userID
+        // WHERE ProjectUsers.project_id = projectid
+        // AND ProjectUsers.user_id = user.user_id;
         ProjectUserShortDto projectUserShortDto =
                 create.select(BEAVERUSERS.USERNAME, PROJECTUSERS.USER_ID, PROJECTUSERS.USER_PROJECT_ID)
                         .from(PROJECTUSERS)
                         .join(BEAVERUSERS)
-                        .on(PROJECTUSERS.USER_ID.eq(user.getUserId()))
+                        .on(PROJECTUSERS.USER_ID.eq(BEAVERUSERS.USER_ID))
                         .where(PROJECTUSERS.PROJECT_ID.eq(projectID))
+                        .and(PROJECTUSERS.USER_ID.eq(user.getUserId()))
                         .fetchOneInto(ProjectUserShortDto.class);
 
         if (projectUserShortDto == null) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
@@ -5,11 +5,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.jooq.DSLContext;
 import org.opm.busybeaver.dto.ProjectUsers.ProjectUserShortDto;
 import org.opm.busybeaver.dto.ProjectUsers.ProjectUserSummaryDto;
-import org.opm.busybeaver.dto.Users.UserSummaryDto;
 import org.opm.busybeaver.enums.BusyBeavConstants;
 import org.opm.busybeaver.enums.ErrorMessageConstants;
 import org.opm.busybeaver.exceptions.ProjectUsers.ProjectUsersExceptions;
 import org.opm.busybeaver.exceptions.Projects.ProjectsExceptions;
+import org.opm.busybeaver.jooq.tables.records.BeaverusersRecord;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Repository;
@@ -33,12 +33,44 @@ public class ProjectUsersRepository {
         this.projectsRepository = projectsRepository;
     }
 
+    public ProjectUserShortDto getUserInProject(int projectID, BeaverusersRecord user, HttpServletRequest request)
+        throws ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException {
+        // SELECT BeaverUsers.username, Project ProjectUsers.user_id, ProjectUsers.user_project_id
+        // FROM ProjectUsers
+        // JOIN BeaverUsers
+        // ON ProjectUsers.user_id = user.userID
+        // WHERE ProjectUsers.project_id = projectid;
+        ProjectUserShortDto projectUserShortDto =
+                create.select(BEAVERUSERS.USERNAME, PROJECTUSERS.USER_ID, PROJECTUSERS.USER_PROJECT_ID)
+                        .from(PROJECTUSERS)
+                        .join(BEAVERUSERS)
+                        .on(PROJECTUSERS.USER_ID.eq(user.getUserId()))
+                        .where(PROJECTUSERS.PROJECT_ID.eq(projectID))
+                        .fetchOneInto(ProjectUserShortDto.class);
+
+        if (projectUserShortDto == null) {
+            ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException userNotInProjectOrProjectDoesNotExistException =
+                    new ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException(
+                            ErrorMessageConstants.USER_NOT_IN_PROJECT_OR_PROJECT_NOT_EXIST.getValue());
+
+            log.error("{}. | RID: {} {}",
+                    ErrorMessageConstants.USER_NOT_IN_PROJECT_OR_PROJECT_NOT_EXIST.getValue(),
+                    request.getAttribute(RID),
+                    System.lineSeparator(),
+                    userNotInProjectOrProjectDoesNotExistException);
+
+            throw userNotInProjectOrProjectDoesNotExistException;
+        }
+
+        return projectUserShortDto;
+    }
+
     public ProjectUserSummaryDto getAllUsersInProject(int projectID) {
         // Get project and team details
         ProjectUserSummaryDto projectUserSummaryDto = projectsRepository.getProjectAndTeamSummary(projectID);
 
         // Get all users in project
-        // SELECT BeaverUsers.username, ProjectUsers.user_id,
+        // SELECT BeaverUsers.username, ProjectUsers.user_id, ProjectUsers.user_project_id
         // FROM ProjectUsers
         // JOIN BeaverUsers
         // ON ProjectUsers.user_id = BeaverUsers.user_id
@@ -112,17 +144,17 @@ public class ProjectUsersRepository {
         return true;
     }
 
-    public void isAssignedToUserInProject(int userID, int projectID, HttpServletRequest request)
+    public void isAssignedToUserInProject(int userProjectID, int projectID, HttpServletRequest request)
             throws ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException {
         // SELECT EXISTS(
         //      SELECT ProjectUsers.project_id,ProjectUsers.user_id
         //      FROM ProjectUsers
         //      WHERE ProjectUsers.project_id = projectID
-        //      AND ProjectUsers.user_id = userID
+        //      AND ProjectUsers.user_project_id = userProjectID
         boolean isValidUserInValidProject = create.fetchExists(
                 create.selectFrom(PROJECTUSERS)
                         .where(PROJECTUSERS.PROJECT_ID.eq(projectID))
-                        .and(PROJECTUSERS.USER_ID.eq(userID))
+                        .and(PROJECTUSERS.USER_PROJECT_ID.eq(userProjectID))
         );
 
         if (!isValidUserInValidProject) {

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/SprintsRepository.java
@@ -137,33 +137,44 @@ public class SprintsRepository {
         // First get all tasks in sprint
         // SELECT Tasks.title, Tasks.task_id, Tasks.priority, Tasks.due_date, Tasks.description,
         //          COUNT(Comments.task_id) as comments,
-        //          Tasks.assigned_to,
-        //          (SELECT BeaverUsers.username FROM BeaverUsers WHERE BeaverUsers.user_id = Tasks.assigned_to),
-        //          Tasks.column_id, Columns.column_index, Columns.column_name, Columns.column_id
+        //          Beaverusers.username, ProjectUsers.user_project_id, ProjectUsers.user_id
+        //          Tasks.column_id, Columns.column_index, Columns.column_title, Columns.column_id
         // FROM Tasks
         // LEFT JOIN Comments
         // ON Tasks.task_id = Comments.task_id
         // JOIN Columns
         // ON Tasks.column_id = Columns.column_id
+        // LEFT JOIN ProjectUsers
+        // ON ProjectUsers.user_project_Id = Tasks.assigned_to
+        // LEFT JOIN BeaverUser
+        // ON BeaverUsers.user_id = ProjectUsers.user_id
         // WHERE Tasks.project_id = projectID
-        // GROUP BY Tasks.task_id, Columns.column_index, Columns.column_title, Columns.column_id;
+        // GROUP BY Tasks.task_id, Columns.column_index, Columns.column_title, Columns.column_id
+        //      Beaverusers.username, Projectusers.user_project_id, Projectusers.user_id;
         @Nullable List<TaskBasicInSprintDto> tasksInSprintInProject =
                 create.select(TASKS.TITLE, TASKS.TASK_ID, TASKS.PRIORITY, TASKS.DUE_DATE, TASKS.DESCRIPTION,
                                 count(COMMENTS.TASK_ID).as(COMMENTS.getName()),
-                                TASKS.ASSIGNED_TO,
-                                create.select(BEAVERUSERS.USERNAME)
-                                        .from(BEAVERUSERS)
-                                        .where(BEAVERUSERS.USER_ID.eq(TASKS.ASSIGNED_TO))
-                                        .asField(BEAVERUSERS.USERNAME.getName()),
+                                BEAVERUSERS.USERNAME, PROJECTUSERS.USER_PROJECT_ID, PROJECTUSERS.USER_ID,
                                 COLUMNS.COLUMN_INDEX, COLUMNS.COLUMN_TITLE, COLUMNS.COLUMN_ID)
                         .from(TASKS)
                         .leftJoin(COMMENTS)
                         .on(TASKS.TASK_ID.eq(COMMENTS.TASK_ID))
                         .join(COLUMNS)
                         .on(TASKS.COLUMN_ID.eq(COLUMNS.COLUMN_ID))
+                        .leftJoin(PROJECTUSERS)
+                        .on(PROJECTUSERS.USER_PROJECT_ID.eq(TASKS.ASSIGNED_TO))
+                        .leftJoin(BEAVERUSERS)
+                        .on(BEAVERUSERS.USER_ID.eq(PROJECTUSERS.USER_ID))
                         .where(TASKS.PROJECT_ID.eq(projectID))
                         .and(TASKS.SPRINT_ID.eq(sprintID))
-                        .groupBy(TASKS.TASK_ID, COLUMNS.COLUMN_INDEX, COLUMNS.COLUMN_TITLE, COLUMNS.COLUMN_ID)
+                        .groupBy(
+                                TASKS.TASK_ID,
+                                COLUMNS.COLUMN_INDEX,
+                                COLUMNS.COLUMN_TITLE,
+                                COLUMNS.COLUMN_ID,
+                                BEAVERUSERS.USERNAME,
+                                PROJECTUSERS.USER_PROJECT_ID,
+                                PROJECTUSERS.USER_ID)
                         .fetchInto(TaskBasicInSprintDto.class);
 
         // Next, get sprint details

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TasksRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/TasksRepository.java
@@ -95,6 +95,7 @@ public class TasksRepository {
                 COLUMNS.COLUMN_ID,
                 COLUMNS.COLUMN_TITLE,
                 COLUMNS.COLUMN_INDEX,
+                PROJECTUSERS.USER_PROJECT_ID,
                 PROJECTUSERS.USER_ID,
                 BEAVERUSERS.USERNAME,
                 SPRINTS.SPRINT_ID,


### PR DESCRIPTION
This patch addresses the discrepancy of using the `user_id` property for the Task `assigned_to` and the commenter_id in a Comment.

Should be using the `user_project_id` from the `ProjectUsers` table.

I tested manually with the Droplet, this seems to be working as expected now. 