### PR TITLE
Fix to ensure can't move if in original position

### DIFF
--- a/frontend/src/components/ProjectColumns.js
+++ b/frontend/src/components/ProjectColumns.js
@@ -149,9 +149,6 @@ const ProjectColumn = memo(( {
   }
 
   const onMovePressed = async (isLeftMove) => {
-    // To safely deep copy in case invalid move
-    setOriginalColumnOrder(JSON.parse(JSON.stringify(columns)));
-
     // Create a shallow copy of columns in order to replace original
     const newColumns = [...columns];
 


### PR DESCRIPTION
Found a bug when moving column away and then back to original position. This fixes that. Test moving column to ensure can't move back to same position. Button to move should be disabled on starting position.