### PR TITLE
Fix add user to project logic

### DIFF
--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/controller/ProjectUsersController.java
@@ -5,6 +5,7 @@ import jakarta.validation.Valid;
 import lombok.extern.slf4j.Slf4j;
 import org.jetbrains.annotations.NotNull;
 import org.opm.busybeaver.controller.ControllerInterfaces.GetUserFromBearerTokenInterface;
+import org.opm.busybeaver.dto.ProjectUsers.ProjectUserShortDto;
 import org.opm.busybeaver.dto.ProjectUsers.ProjectUserSummaryDto;
 import org.opm.busybeaver.dto.SmallJsonResponse;
 import org.opm.busybeaver.dto.Users.UserDto;
@@ -48,19 +49,16 @@ public class ProjectUsersController implements GetUserFromBearerTokenInterface {
     }
 
     @PostMapping(PROJECT_PATH + "/{projectID}" + USERS_PATH)
-    public SmallJsonResponse addUserToProject(
+    public ProjectUserShortDto addUserToProject(
             @NotNull HttpServletRequest request,
             @PathVariable int projectID,
             @Valid @RequestBody UsernameDto usernameDto,
             @ModelAttribute(BusyBeavConstants.Constants.USER_KEY_VAL) UserDto userDto
     ) {
-        projectUsersService.addUserToProject(userDto, projectID, usernameDto, request);
+        ProjectUserShortDto projectUserShortDto = projectUsersService.addUserToProject(userDto, projectID, usernameDto, request);
         log.info("Added a user to a project. | RID: {}", request.getAttribute(RID));
 
-        return new SmallJsonResponse(
-                HttpStatus.OK.value(),
-                usernameDto.username() + SuccessMessageConstants.USER_WAS_ADDED_TO_PROJECT.getValue()
-        );
+        return projectUserShortDto;
     }
 
     @DeleteMapping(PROJECT_PATH + "/{projectID}" + USERS_PATH)

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/repository/ProjectUsersRepository.java
@@ -118,6 +118,14 @@ public class ProjectUsersRepository {
         return (projectUserCount > 1);
     }
 
+    public boolean isUserInProject(int userID, int projectID) {
+        return create.fetchExists(
+                create.selectFrom(PROJECTUSERS)
+                        .where(PROJECTUSERS.PROJECT_ID.eq(projectID))
+                        .and(PROJECTUSERS.USER_ID.eq(userID))
+        );
+    }
+
     public boolean isUserInProjectAndDoesProjectExist(int userID, int projectID, HttpServletRequest request)
             throws ProjectsExceptions.UserNotInProjectOrProjectDoesNotExistException {
         // SELECT EXISTS(

--- a/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectUsersService.java
+++ b/backend/busybeaver/src/main/java/org/opm/busybeaver/service/ProjectUsersService.java
@@ -55,7 +55,7 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
        return projectUserSummaryDto;
     }
 
-    public void addUserToProject(
+    public ProjectUserShortDto addUserToProject(
             UserDto userDto,
             int projectID,
             @NotNull UsernameDto usernameDto,
@@ -69,7 +69,7 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
         BeaverusersRecord userToAdd = usersRepository.getUserByUsername(usernameDto.username(), request);
 
         // Verify user is not in project
-        if (projectUsersRepository.isUserInProjectAndDoesProjectExist(userToAdd.getUserId(), projectID, request)) {
+        if (projectUsersRepository.isUserInProject(userToAdd.getUserId(), projectID)) {
             ProjectUsersExceptions.UserAlreadyInProject userAlreadyInProject =
                     new ProjectUsersExceptions.UserAlreadyInProject(
                             ErrorMessageConstants.USER_ALREADY_IN_PROJECT.getValue());
@@ -88,6 +88,8 @@ public final class ProjectUsersService implements ValidateUserAndProjectInterfac
 
         // Update last updated for project
         projectsRepository.updateLastUpdatedForProject(projectID);
+
+        return projectUsersRepository.getUserInProject(projectID, userToAdd, request);
     }
 
     public void removeUserFromProject(


### PR DESCRIPTION
Previously unable to add a user due to faulty logic. Updated logic and now updated the return data from adding a successful user to include their `userID`, `userProjectID` and `username` for easy updating of display data.