### PR TITLE
Refactor error handling to display team-related errors exclusively in…

### DIFF
--- a/frontend/src/components/UserHomepage.js
+++ b/frontend/src/components/UserHomepage.js
@@ -18,6 +18,7 @@ const UserHomepage = () => {
   const [selectedTeam, setSelectedTeam] = useState(null);
   const [teamMembers, setTeamMembers] = useState([]);
   const [loadingMembers, setLoadingMembers] = useState(false);
+  const [teamError, setTeamError] = useState('');
   const [membersError, setMembersError] = useState('');
   const [error, setError] = useState('');
   const navigate = useNavigate();
@@ -143,7 +144,7 @@ const UserHomepage = () => {
       fetchTeamMembers(teamID); // Refresh team members list
     } catch (error) {
       console.error('Add Member Error:', error);
-      setError('Failed to add team member.');
+      setTeamError('Failed to add team member.');
     }
   };
   
@@ -166,7 +167,7 @@ const UserHomepage = () => {
       fetchTeamMembers(teamID); // Refresh team members list
     } catch (error) {
       console.error('Remove Member Error:', error);
-      setError('Failed to remove team member.');
+      setTeamError('Failed to remove team member.');
     }
   };
   
@@ -332,7 +333,7 @@ const UserHomepage = () => {
             onClose={() => setIsAddMemberModalOpen(false)}
             onSubmit={(memberName) => handleAddMember(selectedTeam.teamID, memberName)}
           />
-          {error && <div className="error-message">{error}</div>}
+          {teamError && <div className="error-message">{teamError}</div>}
           {renderTeams()}
         </aside>
         <main className="project-list">

--- a/frontend/src/components/UserHomepage.js
+++ b/frontend/src/components/UserHomepage.js
@@ -123,7 +123,7 @@ const UserHomepage = () => {
       setError('');
     } catch (error) {
       console.error('Add Team Error:', error);
-      setError('Failed to add team.');
+      setTeamError('Failed to add team.');
     }
     setIsAddTeamModalOpen(false);
   };
@@ -204,7 +204,7 @@ const UserHomepage = () => {
       setTeamMembers([]); // Clear team members state
     } catch (error) {
       console.error('Delete Team Error:', error);
-      setError('Failed to delete team.');
+      setTeamError('Failed to delete team.');
     }
   };
   


### PR DESCRIPTION
… the team column 

Errors messages such as Failed to Add Team Member when the user adds a username that does not exist used to display in both the team column and the bottom of the page. Now the error message displays only in the team column.